### PR TITLE
Fix filter reset on pagination and persist pagination controls

### DIFF
--- a/components/search/SearchPage.tsx
+++ b/components/search/SearchPage.tsx
@@ -15,7 +15,7 @@ import { Pagination } from '@/components/search/paginated-search'
 export function SearchPage() {
   const [viewMode, setViewMode] = React.useState<'table' | 'grid'>('table')
   const [resultType, setResultType] = React.useState<string>('manuscripts')
-  const { data, search } = useSafeSearch(resultType)
+  const { data, search, lastURL } = useSafeSearch(resultType)
   const [limit, setLimit] = React.useState(20)
 
   const renderMap = FILTER_RENDER_MAP[resultType] ?? {}
@@ -31,13 +31,21 @@ export function SearchPage() {
 
   const handlePage = (page: number) => {
     const offset = (page - 1) * limit
-    const url = `${baseFacetURL}?limit=${limit}&offset=${offset}`
-    search(url)
+    const url = new URL(lastURL.current || baseFacetURL)
+    url.searchParams.set('offset', String(offset))
+    url.searchParams.set('limit', String(limit))
+
+    search(url.toString())
   }
 
   const handleLimitChange = (newLimit: number) => {
     setLimit(newLimit)
-    search(`${baseFacetURL}?limit=${newLimit}&offset=0`)
+
+    const url = new URL(lastURL.current || baseFacetURL)
+    url.searchParams.set('limit', String(newLimit))
+    url.searchParams.set('offset', '0')
+
+    search(url.toString())
   }
 
   return (
@@ -92,20 +100,19 @@ export function SearchPage() {
             />
           </div>
           <div className="p-6 overflow-auto flex-1">
-            {hasMap && data.results.length > 0 ? (
-              <>
-                {data.count > limit && (
-                  <div className="mt-4 flex justify-center border rounded-md bg-white py-2">
-                    <Pagination
-                      count={data.count}
-                      limit={data.limit}
-                      offset={data.offset}
-                      onPageChange={handlePage}
-                      onLimitChange={handleLimitChange}
-                    />
-                  </div>
-                )}
-                {viewMode === 'table' ? (
+
+            <>
+              <div className="mt-4 flex justify-center border rounded-md bg-white py-2">
+                <Pagination
+                  count={data.count}
+                  limit={data.limit}
+                  offset={data.offset}
+                  onPageChange={handlePage}
+                  onLimitChange={handleLimitChange}
+                />
+              </div>
+              {hasMap && data.results.length > 0 ? (
+                viewMode === 'table' ? (
                   <ManuscriptsTable results={data.results} />
                 ) : (
                   resultType === 'images' ? (
@@ -115,24 +122,23 @@ export function SearchPage() {
                       No Grid view mode available.
                     </div>
                   )
-                )}
-                {data.count > limit && (
-                  <div className="mt-4 flex justify-center border rounded-md bg-white py-2">
-                    <Pagination
-                      count={data.count}
-                      limit={data.limit}
-                      offset={data.offset}
-                      onPageChange={handlePage}
-                      onLimitChange={handleLimitChange}
-                    />
-                  </div>
-                )}
-              </>
-            ) : (
-              <p className="text-center text-sm text-muted-foreground">
-                No results to display.
-              </p>
-            )}
+                )
+              ) : (
+                <p className="text-center text-sm text-muted-foreground">
+                  No results to display.
+                </p>
+              )}
+              <div className="mt-4 flex justify-center border rounded-md bg-white py-2">
+                <Pagination
+                  count={data.count}
+                  limit={data.limit}
+                  offset={data.offset}
+                  onPageChange={handlePage}
+                  onLimitChange={handleLimitChange}
+                />
+              </div>
+            </>
+
           </div>
         </main>
       </div>

--- a/components/search/paginated-search.tsx
+++ b/components/search/paginated-search.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 type Props = {
   count: number
@@ -63,14 +64,15 @@ export function Pagination({
 
       {/* Page controls */}
       {showPageControls && (
-        <nav className="flex items-center gap-1 text-sm flex-wrap">
+        <nav className="flex items-center gap-1 text-sm flex-wrap" aria-label="Pagination">
           <Button
             variant="ghost"
             size="sm"
             onClick={() => onPageChange(currentPage - 1)}
             disabled={currentPage === 1}
+            aria-label="Previous page"
           >
-            ◄
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </Button>
 
           {pages.map((page, i) =>
@@ -83,10 +85,10 @@ export function Pagination({
                 key={page}
                 variant={page === currentPage ? 'default' : 'ghost'}
                 size="sm"
-                onClick={() => onPageChange(page)}
-                className={cn(
-                  page === currentPage && 'font-semibold'
-                )}
+                onClick={() => onPageChange(page as number)}
+                className={cn(page === currentPage && 'font-semibold')}
+                aria-current={page === currentPage ? 'page' : undefined}
+                aria-label={page === currentPage ? `Page ${page}, current` : `Go to page ${page}`}
               >
                 {page}
               </Button>
@@ -98,8 +100,9 @@ export function Pagination({
             size="sm"
             onClick={() => onPageChange(currentPage + 1)}
             disabled={currentPage === totalPages}
+            aria-label="Next page"
           >
-            ►
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
           </Button>
         </nav>
       )}

--- a/components/search/paginated-search.tsx
+++ b/components/search/paginated-search.tsx
@@ -23,7 +23,7 @@ export function Pagination({
   const totalPages = Math.ceil(count / limit)
   const currentPage = Math.floor(offset / limit) + 1
 
-  if (totalPages <= 1) return null
+  const showPageControls = totalPages > 1
 
   const generatePages = () => {
     const pages: (number | 'ellipsis')[] = []
@@ -62,45 +62,47 @@ export function Pagination({
       </div>
 
       {/* Page controls */}
-      <nav className="flex items-center gap-1 text-sm flex-wrap">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onPageChange(currentPage - 1)}
-          disabled={currentPage === 1}
-        >
-          ◄
-        </Button>
+      {showPageControls && (
+        <nav className="flex items-center gap-1 text-sm flex-wrap">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          >
+            ◄
+          </Button>
 
-        {pages.map((page, i) =>
-          page === 'ellipsis' ? (
-            <span key={`ellipsis-${i}`} className="px-2 text-gray-500">
-              …
-            </span>
-          ) : (
-            <Button
-              key={page}
-              variant={page === currentPage ? 'default' : 'ghost'}
-              size="sm"
-              onClick={() => onPageChange(page)}
-              className={cn(
-                page === currentPage && 'font-semibold'
-              )}
-            >
-              {page}
-            </Button>
-          )
-        )}
+          {pages.map((page, i) =>
+            page === 'ellipsis' ? (
+              <span key={`ellipsis-${i}`} className="px-2 text-gray-500">
+                …
+              </span>
+            ) : (
+              <Button
+                key={page}
+                variant={page === currentPage ? 'default' : 'ghost'}
+                size="sm"
+                onClick={() => onPageChange(page)}
+                className={cn(
+                  page === currentPage && 'font-semibold'
+                )}
+              >
+                {page}
+              </Button>
+            )
+          )}
 
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onPageChange(currentPage + 1)}
-          disabled={currentPage === totalPages}
-        >
-          ►
-        </Button>
-      </nav>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+          >
+            ►
+          </Button>
+        </nav>
+      )}
     </div>
   )
 }

--- a/utils/useSafeSearch.ts
+++ b/utils/useSafeSearch.ts
@@ -8,10 +8,12 @@ const EMPTY: SafeData = { facets: {}, results: [], count: 0, next: null, previou
 export function useSafeSearch(resultType: string) {
   const [data, setData] = useState<SafeData>(EMPTY)
   const lastGood = useRef<SafeData>(EMPTY)
+  const lastURL = useRef<string | undefined>()
 
   const performSearch = useCallback(
     async (url?: string) => {
       if (!RESULT_TYPE_API_MAP[resultType]) return
+      lastURL.current = url
 
       const resp = await fetchFacetsAndResults(resultType, url)
       if (resp.ok) {
@@ -25,6 +27,7 @@ export function useSafeSearch(resultType: string) {
 
   useEffect(() => {
     lastGood.current = EMPTY
+    lastURL.current = undefined
     setData(EMPTY)
 
     if (RESULT_TYPE_API_MAP[resultType]) {
@@ -32,5 +35,5 @@ export function useSafeSearch(resultType: string) {
     }
   }, [resultType, performSearch])
 
-  return { data, search: performSearch }
+  return { data, search: performSearch, lastURL }
 }


### PR DESCRIPTION
- Ensure filtered query parameters persist when navigating pages
- Always show 'results per page' selector regardless of result count
- Keep Pagination component rendered at all times
- Conditionally hide page buttons if only one page exists

- [x] [Fix filter reset on pagination and persist pagination controls](https://github.com/archetype-pal/frontend/commit/9dcc2c3525ae9150810750a0d2c5d4139e360b5f)

