### PR TITLE
feat(backoffice): review queue, quality dashboard, notifications popover, and supporting infra

### DIFF
--- a/app/backoffice/annotations/page.tsx
+++ b/app/backoffice/annotations/page.tsx
@@ -26,6 +26,7 @@ import { ConfirmDialog } from '@/components/backoffice/common/confirm-dialog';
 import { getGraphs, deleteGraph } from '@/services/backoffice/annotations';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
+import { runBulkAction } from '@/lib/backoffice/bulk-action';
 import type { GraphItem } from '@/types/backoffice';
 import { toast } from 'sonner';
 
@@ -193,13 +194,14 @@ export default function AnnotationsPage() {
       variant: 'destructive',
       icon: <Trash2 className="h-3 w-3" />,
       action: async (ids) => {
-        try {
-          await Promise.all(ids.map((id) => deleteGraph(token!, Number(id))));
-          toast.success(`${ids.length} annotation(s) deleted`);
-          queryClient.invalidateQueries({ queryKey: backofficeKeys.graphs.all() });
-        } catch {
-          toast.error('Failed to delete some annotations');
-        }
+        await runBulkAction({
+          ids,
+          action: (id) => deleteGraph(token!, Number(id)),
+          invalidate: () =>
+            queryClient.invalidateQueries({ queryKey: backofficeKeys.graphs.all() }),
+          pastTense: 'deleted',
+          noun: 'annotation',
+        });
       },
     },
   ];

--- a/app/backoffice/carousel/page.tsx
+++ b/app/backoffice/carousel/page.tsx
@@ -167,23 +167,31 @@ export default function CarouselPage() {
       // Optimistic cache update
       queryClient.setQueryData(backofficeKeys.carousel.all(), updated);
 
-      Promise.all(
-        updated
-          .filter(
-            (item, i) =>
-              currentSorted[i]?.id !== item.id || currentSorted[i]?.ordering !== item.ordering
-          )
-          .map((item) =>
-            updateCarouselItemJson(token!, item.id, {
-              ordering: item.ordering,
-            })
-          )
-      )
-        .then(() => invalidate())
-        .catch(() => {
-          toast.error('Failed to reorder items');
-          invalidate();
-        });
+      // `allSettled` so a single failed PATCH doesn't make the whole
+      // reorder appear to fail when most items repositioned correctly.
+      // Always invalidate — successes still need to be reflected, and the
+      // optimistic state must reconcile with the server's truth.
+      const updates = updated.filter(
+        (item, i) =>
+          currentSorted[i]?.id !== item.id || currentSorted[i]?.ordering !== item.ordering
+      );
+      Promise.allSettled(
+        updates.map((item) =>
+          updateCarouselItemJson(token!, item.id, {
+            ordering: item.ordering,
+          })
+        )
+      ).then((results) => {
+        invalidate();
+        const failed = results.filter((r) => r.status === 'rejected').length;
+        if (failed > 0) {
+          toast.error(
+            failed === results.length
+              ? 'Failed to reorder items'
+              : `${failed} of ${results.length} updates failed`
+          );
+        }
+      });
     },
     [items, token, queryClient, invalidate]
   );

--- a/app/backoffice/comments/page.tsx
+++ b/app/backoffice/comments/page.tsx
@@ -9,14 +9,12 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ConfirmDialog } from '@/components/backoffice/common/confirm-dialog';
-import {
-  getComments,
-  approveComment,
-  rejectComment,
-  deleteComment,
-} from '@/services/backoffice/publications';
+import { approveComment, rejectComment, deleteComment } from '@/services/backoffice/publications';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
+import { runBulkAction } from '@/lib/backoffice/bulk-action';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
 import type { CommentItem } from '@/types/backoffice';
 
 export default function CommentsPage() {
@@ -28,10 +26,20 @@ export default function CommentsPage() {
   const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
   const [bulkAction, setBulkAction] = useState<'approve' | 'reject' | 'delete' | null>(null);
 
+  // Walk all pages so the moderation queue shows every matching comment.
+  // The earlier `getComments(token, ...)` returned only the first DRF page
+  // (20), and the page has no pagination control — pending comments past
+  // the 20th would be invisible to moderators until earlier ones cleared.
   const { data } = useQuery({
     queryKey: backofficeKeys.comments.list(filter),
-    queryFn: () =>
-      getComments(token!, filter === 'all' ? undefined : { is_approved: filter === 'approved' }),
+    queryFn: () => {
+      const params = new URLSearchParams({ limit: '100' });
+      if (filter !== 'all') params.set('is_approved', String(filter === 'approved'));
+      return walkPaginated<CommentItem>(
+        `/api/v1/media/management/comments/?${params.toString()}`,
+        (path) => authFetch(path, token!)
+      );
+    },
     enabled: !!token,
   });
 
@@ -80,7 +88,7 @@ export default function CommentsPage() {
     },
   });
 
-  const comments = data?.results ?? [];
+  const comments = data ?? [];
 
   const toggleSelect = (id: number) => {
     setSelected((prev) => {
@@ -102,21 +110,18 @@ export default function CommentsPage() {
   const handleBulkAction = async () => {
     if (!bulkAction || selected.size === 0) return;
     const ids = Array.from(selected);
-    try {
-      if (bulkAction === 'approve') {
-        await Promise.all(ids.map((id) => approveComment(token!, id)));
-        toast.success(`${ids.length} comment(s) approved`);
-      } else if (bulkAction === 'reject') {
-        await Promise.all(ids.map((id) => rejectComment(token!, id)));
-        toast.success(`${ids.length} comment(s) rejected`);
-      } else if (bulkAction === 'delete') {
-        await Promise.all(ids.map((id) => deleteComment(token!, id)));
-        toast.success(`${ids.length} comment(s) deleted`);
-      }
-      invalidate();
-    } catch {
-      toast.error(`Failed to ${bulkAction} some comments`);
-    }
+    const opts = {
+      approve: { action: (id: number) => approveComment(token!, id), pastTense: 'approved' },
+      reject: { action: (id: number) => rejectComment(token!, id), pastTense: 'rejected' },
+      delete: { action: (id: number) => deleteComment(token!, id), pastTense: 'deleted' },
+    }[bulkAction];
+    await runBulkAction({
+      ids,
+      action: opts.action,
+      invalidate,
+      pastTense: opts.pastTense,
+      noun: 'comment',
+    });
     setBulkConfirmOpen(false);
     setBulkAction(null);
   };
@@ -132,7 +137,7 @@ export default function CommentsPage() {
         <MessageSquare className="h-6 w-6 text-primary" />
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Comment Moderation</h1>
-          <p className="text-sm text-muted-foreground">{data?.count ?? '...'} comments</p>
+          <p className="text-sm text-muted-foreground">{data?.length ?? '...'} comments</p>
         </div>
       </div>
 

--- a/app/backoffice/hands/[id]/page.tsx
+++ b/app/backoffice/hands/[id]/page.tsx
@@ -22,8 +22,10 @@ import { Badge } from '@/components/ui/badge';
 import { ConfirmDialog } from '@/components/backoffice/common/confirm-dialog';
 import { EntityEditorActions } from '@/components/backoffice/common/entity-editor-actions';
 import { getHand, updateHand, deleteHand } from '@/services/backoffice/scribes';
-import { getItemImages } from '@/services/backoffice/manuscripts';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
+import type { AdminItemImage } from '@/services/backoffice/manuscripts';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
 import { useUnsavedGuard } from '@/hooks/backoffice/use-unsaved-guard';
 import { useKeyboardShortcut } from '@/hooks/backoffice/use-keyboard-shortcut';
@@ -49,14 +51,21 @@ export default function HandDetailPage({ params }: { params: Promise<{ id: strin
   const [dirty, setDirty] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  // Fetch images for the hand's item part
+  // Fetch images for the hand's item part. Walk all pages — `limit: 200`
+  // was silently capped at DRF's max_limit=100, so editors associating a
+  // hand with images on a multi-folio cartulary couldn't reach folios
+  // past the 100th.
   const { data: imagesData, isLoading: imagesLoading } = useQuery({
     queryKey: ['backoffice', 'item-images', hand?.item_part],
-    queryFn: () => getItemImages(token!, { item_part: hand!.item_part, limit: 200 }),
+    queryFn: () =>
+      walkPaginated<AdminItemImage>(
+        `/api/v1/manuscripts/management/item-images/?item_part=${hand!.item_part}&limit=100`,
+        (path) => authFetch(path, token!)
+      ),
     enabled: !!token && !!hand?.item_part,
   });
 
-  const availableImages = useMemo(() => imagesData?.results ?? [], [imagesData]);
+  const availableImages = useMemo(() => imagesData ?? [], [imagesData]);
 
   useEffect(() => {
     if (hand) {

--- a/app/backoffice/hands/page.tsx
+++ b/app/backoffice/hands/page.tsx
@@ -8,8 +8,9 @@ import { PenTool, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { DataTable, sortableHeader } from '@/components/backoffice/common/data-table';
-import { getHands } from '@/services/backoffice/scribes';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
 import type { HandListItem } from '@/types/backoffice';
 
 const columns: ColumnDef<HandListItem>[] = [
@@ -81,9 +82,16 @@ const columns: ColumnDef<HandListItem>[] = [
 export default function HandsPage() {
   const { token } = useAuth();
 
+  // The earlier `getHands(token)` returned only the first DRF page (20),
+  // but the header showed `data.count` — admins saw "150 hands" with only
+  // 20 rows visible. Walk all pages so the count and the table agree, and
+  // client-side search/pagination on the DataTable spans the full set.
   const { data } = useQuery({
     queryKey: backofficeKeys.hands.all(),
-    queryFn: () => getHands(token!),
+    queryFn: () =>
+      walkPaginated<HandListItem>('/api/v1/management/scribes/hands/?limit=100', (path) =>
+        authFetch(path, token!)
+      ),
     enabled: !!token,
   });
 
@@ -93,13 +101,13 @@ export default function HandsPage() {
         <PenTool className="h-6 w-6 text-primary" />
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Hands</h1>
-          <p className="text-sm text-muted-foreground">{data?.count ?? '...'} hands</p>
+          <p className="text-sm text-muted-foreground">{data?.length ?? '...'} hands</p>
         </div>
       </div>
 
       <DataTable
         columns={columns}
-        data={data?.results ?? []}
+        data={data ?? []}
         searchColumn="name"
         searchPlaceholder="Search hands..."
         pageSize={25}

--- a/app/backoffice/image-texts/[textId]/page.tsx
+++ b/app/backoffice/image-texts/[textId]/page.tsx
@@ -26,6 +26,7 @@ import {
   type ImageTextDetail,
   type ImageTextStatus,
 } from '@/services/image-texts';
+import { fetchManuscriptImage } from '@/services/manuscripts';
 
 const STATUSES: ImageTextStatus[] = ['Draft', 'Review', 'Live', 'Reviewed'];
 const TYPES = ['Transcription', 'Translation'];
@@ -38,10 +39,25 @@ export default function ImageTextEditorPage({ params }: { params: Promise<{ text
   const { token } = useAuth();
   const queryClient = useQueryClient();
 
-  const { data: text, isLoading } = useQuery<ImageTextDetail | null>({
+  const {
+    data: text,
+    isLoading,
+    isError,
+    error: fetchError,
+  } = useQuery<ImageTextDetail | null>({
     queryKey: queryKey(textId),
     queryFn: () => fetchImageText(textId, token!),
     enabled: !!token && Number.isFinite(textId),
+  });
+
+  // The text record carries `item_image` but not the parent `item_part`,
+  // which the public-viewer URL needs for the back-link in the layout
+  // header. Resolve it once the text loads so the "Public viewer" link is
+  // valid (the previous hard-coded `/manuscripts/0/...` 404'd the back-link).
+  const { data: image } = useQuery({
+    queryKey: ['backoffice', 'item-image', text?.item_image],
+    queryFn: () => fetchManuscriptImage(String(text!.item_image)),
+    enabled: !!text,
   });
 
   const [content, setContent] = useState('');
@@ -83,6 +99,19 @@ export default function ImageTextEditorPage({ params }: { params: Promise<{ text
     dirty
   );
 
+  if (isError) {
+    // The service throws on non-404 errors so a transient outage doesn't
+    // get hidden behind a perpetual spinner. Surface the error message so
+    // the user knows to retry rather than wait indefinitely.
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+        <p>Could not load image text.</p>
+        <p className="text-xs">
+          {fetchError instanceof Error ? fetchError.message : String(fetchError)}
+        </p>
+      </div>
+    );
+  }
   if (isLoading || !text) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -183,14 +212,18 @@ export default function ImageTextEditorPage({ params }: { params: Promise<{ text
       </div>
 
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Link
-          href={`/manuscripts/0/images/${text.item_image}/texts/${text.id}`}
-          className="inline-flex items-center gap-1 hover:underline"
-          target="_blank"
-        >
-          <ExternalLink className="h-3 w-3" /> Public viewer
-        </Link>
-        <span>·</span>
+        {image && (
+          <>
+            <Link
+              href={`/manuscripts/${image.item_part}/images/${text.item_image}/texts`}
+              className="inline-flex items-center gap-1 hover:underline"
+              target="_blank"
+            >
+              <ExternalLink className="h-3 w-3" /> Public viewer
+            </Link>
+            <span>·</span>
+          </>
+        )}
         <span>Modified {new Date(text.modified).toLocaleString()}</span>
       </div>
     </div>

--- a/app/backoffice/manuscripts/new/page.tsx
+++ b/app/backoffice/manuscripts/new/page.tsx
@@ -21,14 +21,15 @@ import {
   createHistoricalItem,
   createItemPart,
   createCurrentItem,
-  getCurrentItems,
   getRepositories,
   getDates,
 } from '@/services/backoffice/manuscripts';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
 import { toast } from 'sonner';
-import type { Repository } from '@/types/backoffice';
+import type { CurrentItemOption, Repository } from '@/types/backoffice';
 import { useModelLabels } from '@/contexts/model-labels-context';
 
 const ITEM_TYPES = [
@@ -67,25 +68,26 @@ export default function NewManuscriptPage() {
     enabled: !!token,
   });
 
-  const repositories: Repository[] = !repositoriesData
-    ? []
-    : Array.isArray(repositoriesData)
-      ? repositoriesData
-      : repositoriesData.results;
+  const repositories: Repository[] = repositoriesData ?? [];
   const dates = datesData ?? [];
 
   const createMut = useMutation({
     mutationFn: async () => {
       if (!token) throw new Error('Not authenticated');
 
-      // Step 1: Find or create CurrentItem (if repository & shelfmark provided)
+      // Step 1: Find or create CurrentItem (if repository & shelfmark provided).
+      // Walk all pages — `limit: 500` was silently capped at DRF's max_limit
+      // (100), so for repositories with >100 current items the find could
+      // miss an existing match and create a duplicate `(repository, shelfmark)`
+      // row. The endpoint doesn't expose `?shelfmark=` filtering, so a full
+      // walk is the only correct option.
       let currentItemId: number | null = null;
       if (repository && shelfmark.trim()) {
-        const existing = await getCurrentItems(token, {
-          repository: Number(repository),
-          limit: 500,
-        });
-        const match = existing.results.find(
+        const existing = await walkPaginated<CurrentItemOption>(
+          `/api/v1/manuscripts/management/current-items/?repository=${Number(repository)}&limit=100`,
+          (path) => authFetch(path, token)
+        );
+        const match = existing.find(
           (ci) => ci.shelfmark.toLowerCase() === shelfmark.trim().toLowerCase()
         );
         if (match) {

--- a/app/backoffice/page.tsx
+++ b/app/backoffice/page.tsx
@@ -155,7 +155,17 @@ export default function BackofficeDashboardPage() {
 
   const publications = useQuery({
     queryKey: backofficeKeys.publications.all(),
-    queryFn: () => getPublications(token!, { limit: 200 }),
+    queryFn: () => getPublications(token!, { limit: 1 }),
+    enabled: !!token,
+  });
+
+  // Separate count-only query for the draft pending-tasks indicator. The
+  // earlier `publications.data?.results?.filter(...).length` only counted
+  // drafts in the first 100 publications (DRF max_limit), silently lying
+  // about the queue depth when a busy editor had >100 publications.
+  const draftPublications = useQuery({
+    queryKey: backofficeKeys.publications.list({ status: 'Draft' }),
+    queryFn: () => getPublications(token!, { limit: 1, status: 'Draft' }),
     enabled: !!token,
   });
 
@@ -179,7 +189,7 @@ export default function BackofficeDashboardPage() {
   });
 
   const pendingCount = pendingComments.data?.count ?? 0;
-  const draftCount = publications.data?.results?.filter((p) => p.status === 'Draft').length ?? 0;
+  const draftCount = draftPublications.data?.count ?? 0;
   const outOfSyncIndexes = searchStats.data?.indexes?.filter((i) => !i.in_sync) ?? [];
   const hasPendingTasks = pendingCount > 0 || draftCount > 0 || outOfSyncIndexes.length > 0;
 
@@ -195,12 +205,20 @@ export default function BackofficeDashboardPage() {
 
   return (
     <div className="space-y-8 max-w-5xl">
-      {/* Greeting */}
+      {/* Greeting — `getGreeting` and `formatDate` read the local clock, so
+          their output depends on timezone. Server (typically UTC) and the
+          researcher's browser (any zone) routinely disagree, which produced
+          a React hydration mismatch warning AND a brief flash of the wrong
+          greeting. `suppressHydrationWarning` lets the client value win
+          without React complaining; the day/greeting then matches the
+          researcher's actual time of day. */}
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight">
+        <h1 className="text-2xl font-semibold tracking-tight" suppressHydrationWarning>
           {getGreeting()}, {firstName}
         </h1>
-        <p className="text-sm text-muted-foreground mt-1">{formatDate()}</p>
+        <p className="text-sm text-muted-foreground mt-1" suppressHydrationWarning>
+          {formatDate()}
+        </p>
       </div>
 
       {/* Pending Tasks */}

--- a/app/backoffice/physical-volumes/page.tsx
+++ b/app/backoffice/physical-volumes/page.tsx
@@ -76,11 +76,7 @@ export default function PhysicalVolumesPage() {
     enabled: !!token,
   });
 
-  const repositories: Repository[] = !repositoriesData
-    ? []
-    : Array.isArray(repositoriesData)
-      ? repositoriesData
-      : repositoriesData.results;
+  const repositories: Repository[] = repositoriesData ?? [];
 
   const filterParams = {
     ...(repoFilter !== '__all' ? { repository: Number(repoFilter) } : {}),

--- a/app/backoffice/publications/page.tsx
+++ b/app/backoffice/publications/page.tsx
@@ -24,14 +24,12 @@ import {
 } from '@/components/backoffice/common/data-table';
 import { FilterBar, type FilterConfig } from '@/components/backoffice/common/filter-bar';
 import { ConfirmDialog } from '@/components/backoffice/common/confirm-dialog';
-import {
-  getPublications,
-  updatePublication,
-  deletePublication,
-} from '@/services/backoffice/publications';
+import { updatePublication, deletePublication } from '@/services/backoffice/publications';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
+import { runBulkAction } from '@/lib/backoffice/bulk-action';
 import type { PublicationListItem } from '@/types/backoffice';
-import { toast } from 'sonner';
 
 const pubFilters: FilterConfig[] = [
   {
@@ -156,14 +154,22 @@ export default function PublicationsPage() {
     execute: (slugs: string[]) => Promise<void>;
   } | null>(null);
 
+  // Walk all pages so the client-side filter spans every publication.
+  // The earlier `getPublications(token, { limit: 200 })` was silently
+  // capped to 100 by DRF's BoundedLimitOffsetPagination, hiding row 101+
+  // from this page (admins doing bulk publish/unpublish couldn't reach them).
   const { data } = useQuery({
     queryKey: backofficeKeys.publications.all(),
-    queryFn: () => getPublications(token!, { limit: 200 }),
+    queryFn: () =>
+      walkPaginated<PublicationListItem>(
+        '/api/v1/media/management/publications/?limit=100',
+        (path) => authFetch(path, token!)
+      ),
     enabled: !!token,
   });
 
   // Client-side filtering
-  const filtered = (data?.results ?? []).filter((pub) => {
+  const filtered = (data ?? []).filter((pub) => {
     if (filterValues.status && filterValues.status !== '__all') {
       if (pub.status !== filterValues.status) return false;
     }
@@ -175,20 +181,21 @@ export default function PublicationsPage() {
     return true;
   });
 
+  const invalidatePubs = () =>
+    queryClient.invalidateQueries({ queryKey: backofficeKeys.publications.all() });
+
   const bulkActions: BulkAction[] = [
     {
       label: 'Publish',
       icon: <CheckCircle className="h-3 w-3" />,
       action: async (slugs) => {
-        try {
-          await Promise.all(
-            slugs.map((slug) => updatePublication(token!, slug, { status: 'Published' }))
-          );
-          toast.success(`${slugs.length} publication(s) published`);
-          queryClient.invalidateQueries({ queryKey: backofficeKeys.publications.all() });
-        } catch {
-          toast.error('Failed to publish some publications');
-        }
+        await runBulkAction({
+          ids: slugs,
+          action: (slug) => updatePublication(token!, slug, { status: 'Published' }),
+          invalidate: invalidatePubs,
+          pastTense: 'published',
+          noun: 'publication',
+        });
       },
     },
     {
@@ -199,15 +206,13 @@ export default function PublicationsPage() {
           label: 'Unpublish',
           slugs,
           execute: async (s) => {
-            try {
-              await Promise.all(
-                s.map((slug) => updatePublication(token!, slug, { status: 'Draft' }))
-              );
-              toast.success(`${s.length} publication(s) unpublished`);
-              queryClient.invalidateQueries({ queryKey: backofficeKeys.publications.all() });
-            } catch {
-              toast.error('Failed to unpublish some publications');
-            }
+            await runBulkAction({
+              ids: s,
+              action: (slug) => updatePublication(token!, slug, { status: 'Draft' }),
+              invalidate: invalidatePubs,
+              pastTense: 'unpublished',
+              noun: 'publication',
+            });
           },
         });
         setBulkConfirmOpen(true);
@@ -222,13 +227,13 @@ export default function PublicationsPage() {
           label: 'Delete',
           slugs,
           execute: async (s) => {
-            try {
-              await Promise.all(s.map((slug) => deletePublication(token!, slug)));
-              toast.success(`${s.length} publication(s) deleted`);
-              queryClient.invalidateQueries({ queryKey: backofficeKeys.publications.all() });
-            } catch {
-              toast.error('Failed to delete some publications');
-            }
+            await runBulkAction({
+              ids: s,
+              action: (slug) => deletePublication(token!, slug),
+              invalidate: invalidatePubs,
+              pastTense: 'deleted',
+              noun: 'publication',
+            });
           },
         });
         setBulkConfirmOpen(true);
@@ -243,7 +248,7 @@ export default function PublicationsPage() {
           <Newspaper className="h-6 w-6 text-primary" />
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Publications</h1>
-            <p className="text-sm text-muted-foreground">{data?.count ?? '...'} publications</p>
+            <p className="text-sm text-muted-foreground">{data?.length ?? '...'} publications</p>
           </div>
         </div>
         <Button size="sm" onClick={() => router.push('/backoffice/publications/new')}>

--- a/app/backoffice/quality/page.tsx
+++ b/app/backoffice/quality/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const QualityDashboard = dynamic(
+  () => import('@/components/backoffice/quality-dashboard').then((m) => m.QualityDashboard),
+  { ssr: false }
+);
+
+export default function QualityPage() {
+  return <QualityDashboard />;
+}

--- a/app/backoffice/repositories/page.tsx
+++ b/app/backoffice/repositories/page.tsx
@@ -16,11 +16,7 @@ export default function RepositoriesPage() {
     <SimpleCrudPage<Repository>
       queryKey={backofficeKeys.repositories.all()}
       queryFn={(token) => getRepositories(token)}
-      getRows={(data) =>
-        data && typeof data === 'object' && 'results' in data
-          ? ((data as { results?: Repository[] }).results ?? [])
-          : []
-      }
+      getRows={(data) => (Array.isArray(data) ? (data as Repository[]) : [])}
       createFn={(token, payload) =>
         createRepository(token, {
           name: String(payload.name ?? ''),

--- a/app/backoffice/review-queue/page.tsx
+++ b/app/backoffice/review-queue/page.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+/**
+ * Phase G.1 — `/backoffice/review-queue` route.
+ *
+ * Staff-only feed of `ImageText` rows in `Review` status, oldest-first.
+ * Each row shows the latest transition (who sent it, when, with what
+ * note) so reviewers can triage without opening every entry.
+ *
+ * Approve → flips to `Live`. Send back → flips to `Draft` with a
+ * required note. Both go through the same `transitionImageText`
+ * service so the audit trail stays honest.
+ */
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { useAuth } from '@/contexts/auth-context';
+import { useStaffGuard } from '@/hooks/backoffice/use-staff-guard';
+import { fetchReviewQueue, transitionImageText, type QueueEntry } from '@/services/backoffice/review-queue';
+import { Button } from '@/components/ui/button';
+
+export default function ReviewQueuePage() {
+  const { token } = useAuth();
+  useStaffGuard();
+  const queryClient = useQueryClient();
+
+  const { data: queue = [], isLoading } = useQuery<QueueEntry[]>({
+    queryKey: ['review-queue'],
+    queryFn: () => fetchReviewQueue(token!),
+    enabled: !!token,
+    refetchInterval: 60_000,
+  });
+
+  if (!token) {
+    return <div className="px-6 py-8 text-sm text-muted-foreground">Sign in to review.</div>;
+  }
+  if (isLoading) {
+    return (
+      <div className="flex h-40 items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (queue.length === 0) {
+    return (
+      <div className="px-6 py-8 text-sm text-muted-foreground">
+        Nothing waiting for review. Quiet day.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 px-6 py-8">
+      <header>
+        <h1 className="font-display text-2xl font-semibold tracking-tight">Review queue</h1>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          {queue.length} {queue.length === 1 ? 'text' : 'texts'} awaiting review, oldest first.
+        </p>
+      </header>
+      <ul className="space-y-2">
+        {queue.map((row) => (
+          <ReviewRow
+            key={row.id}
+            row={row}
+            onTransitioned={() => queryClient.invalidateQueries({ queryKey: ['review-queue'] })}
+            token={token}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ReviewRow({
+  row,
+  token,
+  onTransitioned,
+}: {
+  row: QueueEntry;
+  token: string;
+  onTransitioned: () => void;
+}) {
+  const [note, setNote] = useState('');
+  const approve = useMutation({
+    mutationFn: () => transitionImageText(token, row.id, { to_status: 'Live' }),
+    onSuccess: () => {
+      toast.success(`Approved → Live`);
+      onTransitioned();
+    },
+    onError: (err: Error) => toast.error('Approve failed', { description: err.message }),
+  });
+  const sendBack = useMutation({
+    mutationFn: () => {
+      if (!note.trim()) {
+        return Promise.reject(new Error('Add a note explaining what needs changing.'));
+      }
+      return transitionImageText(token, row.id, { to_status: 'Draft', note });
+    },
+    onSuccess: () => {
+      toast.success('Sent back to Draft');
+      setNote('');
+      onTransitioned();
+    },
+    onError: (err: Error) => toast.error('Send-back failed', { description: err.message }),
+  });
+
+  return (
+    <li className="rounded-lg border bg-card p-3 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <Link href={`/backoffice/image-texts/${row.id}`} className="font-medium hover:underline">
+            #{row.id} — {row.type} on image {row.item_image}
+          </Link>
+          {row.last_transition ? (
+            <p className="text-xs text-muted-foreground">
+              Sent for review by <strong>{row.last_transition.actor_username ?? 'unknown'}</strong>{' '}
+              on {new Date(row.last_transition.created).toLocaleString()}
+              {row.last_transition.note ? ` — “${row.last_transition.note}”` : ''}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">No transition history.</p>
+          )}
+          {row.review_assignee_username ? (
+            <p className="text-xs">
+              Assigned to <strong>{row.review_assignee_username}</strong>
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-col items-stretch gap-1.5 sm:items-end">
+          <Button
+            size="sm"
+            onClick={() => approve.mutate()}
+            disabled={approve.isPending}
+            className="h-7"
+          >
+            {approve.isPending ? 'Approving…' : 'Approve → Live'}
+          </Button>
+          <input
+            type="text"
+            placeholder="Note for editor (required for send-back)"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            className="h-7 w-72 rounded-md border bg-background px-2 text-xs"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => sendBack.mutate()}
+            disabled={sendBack.isPending}
+            className="h-7"
+          >
+            {sendBack.isPending ? 'Sending…' : 'Send back to Draft'}
+          </Button>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/app/backoffice/scribes/[id]/page.tsx
+++ b/app/backoffice/scribes/[id]/page.tsx
@@ -13,11 +13,14 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { ConfirmDialog } from '@/components/backoffice/common/confirm-dialog';
 import { EntityEditorActions } from '@/components/backoffice/common/entity-editor-actions';
-import { getScribe, updateScribe, deleteScribe, getHands } from '@/services/backoffice/scribes';
+import { getScribe, updateScribe, deleteScribe } from '@/services/backoffice/scribes';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
 import { useUnsavedGuard } from '@/hooks/backoffice/use-unsaved-guard';
 import { useKeyboardShortcut } from '@/hooks/backoffice/use-keyboard-shortcut';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
+import type { HandListItem } from '@/types/backoffice';
 
 export default function ScribeDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: rawId } = use(params);
@@ -32,9 +35,17 @@ export default function ScribeDetailPage({ params }: { params: Promise<{ id: str
     enabled: !!token,
   });
 
+  // Walk all pages — `getHands(token, { scribe })` returned only the
+  // first DRF page (default 20). A productive scribe can have many hands
+  // across many manuscripts; the per-scribe listing in the editor would
+  // hide entries 21+ and the count would lie about the actual breadth.
   const { data: hands } = useQuery({
     queryKey: backofficeKeys.hands.list({ scribe: id }),
-    queryFn: () => getHands(token!, { scribe: id }),
+    queryFn: () =>
+      walkPaginated<HandListItem>(
+        `/api/v1/management/scribes/hands/?scribe=${id}&limit=100`,
+        (path) => authFetch(path, token!)
+      ),
     enabled: !!token,
   });
 
@@ -156,15 +167,15 @@ export default function ScribeDetailPage({ params }: { params: Promise<{ id: str
       {/* Hands list */}
       <div className="space-y-3">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium">Hands ({hands?.results?.length ?? 0})</h3>
+          <h3 className="text-sm font-medium">Hands ({hands?.length ?? 0})</h3>
         </div>
-        {hands?.results?.length === 0 ? (
+        {hands?.length === 0 ? (
           <div className="rounded-md border border-dashed p-6 text-center text-muted-foreground text-sm">
             No hands associated with this scribe.
           </div>
         ) : (
           <div className="rounded-md border divide-y">
-            {hands?.results?.map((hand) => (
+            {hands?.map((hand) => (
               <Link
                 key={hand.id}
                 href={`/backoffice/hands/${hand.id}`}

--- a/app/backoffice/scribes/page.tsx
+++ b/app/backoffice/scribes/page.tsx
@@ -18,9 +18,11 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { DataTable, sortableHeader } from '@/components/backoffice/common/data-table';
-import { getScribes, createScribe } from '@/services/backoffice/scribes';
+import { createScribe } from '@/services/backoffice/scribes';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
 import { toast } from 'sonner';
 import type { ScribeListItem } from '@/types/backoffice';
 
@@ -82,9 +84,16 @@ export default function ScribesPage() {
   const [addOpen, setAddOpen] = useState(false);
   const [newName, setNewName] = useState('');
 
+  // Walk all pages so the displayed count and rows agree — the earlier
+  // `getScribes(token)` returned only the first DRF page (20), but the
+  // header showed `data.count`, leaving admins with "150 scribes" + 20
+  // visible rows and no pagination control.
   const { data } = useQuery({
     queryKey: backofficeKeys.scribes.all(),
-    queryFn: () => getScribes(token!),
+    queryFn: () =>
+      walkPaginated<ScribeListItem>('/api/v1/management/scribes/scribes/?limit=100', (path) =>
+        authFetch(path, token!)
+      ),
     enabled: !!token,
   });
 
@@ -109,13 +118,13 @@ export default function ScribesPage() {
         <Users className="h-6 w-6 text-primary" />
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Scribes</h1>
-          <p className="text-sm text-muted-foreground">{data?.count ?? '...'} scribes</p>
+          <p className="text-sm text-muted-foreground">{data?.length ?? '...'} scribes</p>
         </div>
       </div>
 
       <DataTable
         columns={columns}
-        data={data?.results ?? []}
+        data={data ?? []}
         searchColumn="name"
         searchPlaceholder="Search scribes..."
         toolbarActions={

--- a/app/backoffice/users/page.tsx
+++ b/app/backoffice/users/page.tsx
@@ -41,6 +41,7 @@ import {
 import { getUsers, createUser, updateUser, deleteUser } from '@/services/backoffice/users';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
+import { runBulkAction } from '@/lib/backoffice/bulk-action';
 import { toast } from 'sonner';
 import type { UserListItem, UserCreatePayload, UserUpdatePayload } from '@/types/backoffice';
 
@@ -212,17 +213,20 @@ export default function UsersPage() {
     },
   });
 
+  // Use `runBulkAction` so a single failed delete doesn't black-hole the
+  // cache invalidation — successful deletes still need to be reflected in
+  // the table even when one row 4xx/5xxs.
   const bulkDeleteMut = useMutation({
-    mutationFn: async (ids: string[]) => {
-      await Promise.all(ids.map((id) => deleteUser(token!, Number(id))));
-    },
+    mutationFn: (ids: string[]) =>
+      runBulkAction({
+        ids,
+        action: (id) => deleteUser(token!, Number(id)),
+        invalidate,
+        pastTense: 'deleted',
+        noun: 'user',
+      }),
     onSuccess: () => {
-      toast.success(`${bulkDeleteIds.length} user(s) deleted`);
-      invalidate();
       setBulkDeleteIds([]);
-    },
-    onError: (err) => {
-      toast.error('Bulk delete failed', { description: formatApiError(err) });
     },
   });
 
@@ -239,16 +243,24 @@ export default function UsersPage() {
     });
   }
 
-  async function handleBulkActivate(ids: string[]) {
-    await Promise.all(ids.map((id) => updateUser(token!, Number(id), { is_active: true })));
-    toast.success(`${ids.length} user(s) activated`);
-    invalidate();
+  function handleBulkActivate(ids: string[]) {
+    return runBulkAction({
+      ids,
+      action: (id) => updateUser(token!, Number(id), { is_active: true }),
+      invalidate,
+      pastTense: 'activated',
+      noun: 'user',
+    });
   }
 
-  async function handleBulkDeactivate(ids: string[]) {
-    await Promise.all(ids.map((id) => updateUser(token!, Number(id), { is_active: false })));
-    toast.success(`${ids.length} user(s) deactivated`);
-    invalidate();
+  function handleBulkDeactivate(ids: string[]) {
+    return runBulkAction({
+      ids,
+      action: (id) => updateUser(token!, Number(id), { is_active: false }),
+      invalidate,
+      pastTense: 'deactivated',
+      noun: 'user',
+    });
   }
 
   function handleBulkDelete(ids: string[]) {

--- a/components/backoffice/carousel/carousel-editor-panel.tsx
+++ b/components/backoffice/carousel/carousel-editor-panel.tsx
@@ -70,7 +70,10 @@ export function CarouselEditorPanel({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+      // Caps Lock makes `e.key` come through as 'S', so lower-case the
+      // letter before comparing — otherwise Cmd/Ctrl+S silently fails to
+      // save for caps-locked users.
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
         e.preventDefault();
         handleSave();
       }

--- a/components/backoffice/common/data-table.tsx
+++ b/components/backoffice/common/data-table.tsx
@@ -33,7 +33,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ChevronLeft, ChevronRight, Search, Columns, Download, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { dismissActionNotification, showActionNotification } from '@/components/ui/action-toast';
+import { escapeCsvField } from '@/lib/backoffice/csv-escape';
 
 export interface BulkAction {
   label: string;
@@ -199,32 +199,6 @@ export function DataTable<TData, TValue>({
 
   const selectedCount = Object.keys(rowSelection).length;
   const selectedIds = Object.keys(rowSelection);
-  const previousSelectedCountRef = useRef(0);
-
-  useEffect(() => {
-    if (!enableRowSelection || !bulkActions?.length) return;
-
-    if (selectedCount === 0) {
-      if (previousSelectedCountRef.current > 0) {
-        dismissActionNotification('data-table-selection-toast');
-      }
-
-      previousSelectedCountRef.current = selectedCount;
-      return;
-    }
-
-    if (selectedCount !== previousSelectedCountRef.current) {
-      showActionNotification({
-        id: 'data-table-selection-toast',
-        kind: 'selected',
-        title: `${selectedCount} row${selectedCount === 1 ? '' : 's'} selected`,
-        description: 'Selection updated.',
-        duration: 1800,
-      });
-    }
-
-    previousSelectedCountRef.current = selectedCount;
-  }, [bulkActions?.length, enableRowSelection, selectedCount]);
 
   function handleExport() {
     const headers = table
@@ -236,19 +210,34 @@ export function DataTable<TData, TValue>({
       headers
         .map((h) => {
           const val = row.getValue(h);
-          const str = String(val ?? '');
-          return str.includes(',') || str.includes('"') ? `"${str.replace(/"/g, '""')}"` : str;
+          // `escapeCsvField` handles delimiters/quotes/newlines AND neutralizes
+          // formula-injection prefixes (`=`, `+`, `-`, `@`, tab, `\r`) so a
+          // backoffice CSV opened in Excel/Sheets can't execute hostile
+          // content from a researcher-edited description or name field.
+          return escapeCsvField(String(val ?? ''));
         })
         .join(',')
     );
 
-    const csv = [headers.join(','), ...rows].join('\n');
+    // Escape the header row through the same path as the data cells —
+    // column ids today are machine identifiers, but a future renaming
+    // could introduce a comma, quote, or formula-prefix character that
+    // would otherwise break CSV alignment for the whole file.
+    const csv = [headers.map(escapeCsvField).join(','), ...rows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
     link.download = `${exportFilename}.csv`;
+    // Append-click-remove instead of bare `.click()` on a detached node.
+    // Modern Chrome/Firefox/Safari trigger the download fine, but older
+    // Firefox versions and some mobile Safari builds silently no-op the
+    // click on an unattached anchor — admins on those browsers got no
+    // export file. Same fix as cycle 179's search-results exporter and
+    // cycle 149's lightbox exporter.
+    document.body.appendChild(link);
     link.click();
+    document.body.removeChild(link);
     URL.revokeObjectURL(url);
   }
 

--- a/components/backoffice/common/help-tooltip.tsx
+++ b/components/backoffice/common/help-tooltip.tsx
@@ -90,9 +90,16 @@ export function FieldLabel({
     >
       {children}
       {required && (
-        <span className="text-destructive" aria-hidden="true">
-          *
-        </span>
+        <>
+          <span className="text-destructive" aria-hidden="true">
+            *
+          </span>
+          {/* Screen readers need a programmatic signal that the field is
+              required — the asterisk alone is aria-hidden, so without this
+              announcement assistive tech users had no way to tell a field
+              was required from the label. */}
+          <span className="sr-only">(required)</span>
+        </>
       )}
       {helpField && <HelpTooltip field={helpField} entry={helpEntry} />}
     </label>

--- a/components/backoffice/common/image-upload-zone.tsx
+++ b/components/backoffice/common/image-upload-zone.tsx
@@ -65,12 +65,33 @@ export function ImageUploadZone({
   const handleFile = useCallback(
     (file: File) => {
       if (!validate(file)) return;
-      const url = URL.createObjectURL(file);
-      setPreviewUrl(url);
+      // Revoke the previous preview URL before overwriting it. Picking a
+      // second file in succession would otherwise orphan the first blob
+      // URL — the browser holds the blob in memory until full page
+      // reload, leaking ~10 MB per replaced upload.
+      setPreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return URL.createObjectURL(file);
+      });
       onFileSelect(file);
     },
     [validate, onFileSelect]
   );
+
+  // Revoke any staged preview URL on unmount so navigating away from a
+  // form with a chosen-but-not-saved file doesn't leak the blob. Read
+  // the latest previewUrl through a ref so the cleanup only runs on
+  // unmount (not on every change — intermediate replacements are
+  // revoked inline by handleFile / handleClear).
+  const previewUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    previewUrlRef.current = previewUrl;
+  }, [previewUrl]);
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    };
+  }, []);
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {

--- a/components/backoffice/common/search-command.tsx
+++ b/components/backoffice/common/search-command.tsx
@@ -152,7 +152,10 @@ export function SearchCommand() {
   // Register Cmd+K / Ctrl+K shortcut
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+      // Caps Lock makes `e.key` come through as 'K', so the literal
+      // 'k' check would silently break the quick-search shortcut for
+      // caps-locked users.
+      if (e.key.toLowerCase() === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         setOpen((prev) => !prev);
       }

--- a/components/backoffice/layout/backoffice-header.tsx
+++ b/components/backoffice/layout/backoffice-header.tsx
@@ -36,7 +36,18 @@ function useBreadcrumbs(segmentLabels: Record<string, string>) {
 
   return segments.map((segment, index) => {
     const href = '/' + segments.slice(0, index + 1).join('/');
-    let label = segmentLabels[segment] ?? decodeURIComponent(segment);
+    // `decodeURIComponent` throws URIError on malformed percent-encoding
+    // (e.g. a stray `%` from a hand-typed URL). Without the guard, the
+    // entire breadcrumb component crashes — and through React's error
+    // propagation, the backoffice header along with it. Fall back to the
+    // raw segment so the page still renders.
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment);
+    } catch {
+      decoded = segment;
+    }
+    let label = segmentLabels[segment] ?? decoded;
 
     // Try to resolve entity name from recent entities for dynamic segments
     if (!segmentLabels[segment] && index > 1) {

--- a/components/backoffice/layout/backoffice-sidebar.tsx
+++ b/components/backoffice/layout/backoffice-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   PenTool,
   Type,
   FileText,
+  ScrollText,
   MessageSquare,
   Image,
   Users,
@@ -79,6 +80,7 @@ function getNavigation(
         { label: 'Scribes', href: '/backoffice/scribes', icon: Users },
         { label: 'Hands', href: '/backoffice/hands', icon: Hand },
         { label: 'Annotations', href: '/backoffice/annotations', icon: PenTool },
+        { label: 'Texts', href: '/backoffice/texts', icon: ScrollText },
         { label: 'Characters', href: '/backoffice/symbols', icon: Type },
       ],
       subGroups: [
@@ -112,6 +114,7 @@ function getNavigation(
       items: [
         { label: 'User Management', href: '/backoffice/users', icon: UserCog },
         { label: 'Search Engine', href: '/backoffice/search-engine', icon: Search },
+        { label: 'Data Quality', href: '/backoffice/quality', icon: Settings },
         { label: 'Translations', href: '/backoffice/translations', icon: Languages },
         { label: 'Site Features', href: '/backoffice/site-features', icon: ToggleLeft },
       ],
@@ -225,7 +228,12 @@ function useSubGroupOpen(label: string, defaultOpen: boolean) {
   const toggle = useCallback(() => {
     setOpen((prev) => {
       const next = !prev;
-      localStorage.setItem(key, next ? '1' : '0');
+      try {
+        localStorage.setItem(key, next ? '1' : '0');
+      } catch {
+        // Quota exceeded / private mode — the sidebar still toggles via
+        // state; the preference just won't persist across reloads.
+      }
       return next;
     });
   }, [key]);

--- a/components/backoffice/manuscripts/current-item-combobox.tsx
+++ b/components/backoffice/manuscripts/current-item-combobox.tsx
@@ -80,11 +80,7 @@ export function CurrentItemCombobox({
   });
 
   const items: CurrentItemOption[] = currentItemsData?.results ?? [];
-  const repositories: Repository[] = !repositoriesData
-    ? []
-    : Array.isArray(repositoriesData)
-      ? repositoriesData
-      : repositoriesData.results;
+  const repositories: Repository[] = repositoriesData ?? [];
 
   const selectedItem = items.find((ci) => ci.id === value);
   const displayValue =

--- a/components/backoffice/manuscripts/current-location-section.tsx
+++ b/components/backoffice/manuscripts/current-location-section.tsx
@@ -20,12 +20,13 @@ import {
   createItemPart,
   updateItemPart,
   createCurrentItem,
-  getCurrentItems,
   getRepositories,
 } from '@/services/backoffice/manuscripts';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
-import type { ItemPartNested, Repository } from '@/types/backoffice';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
+import type { CurrentItemOption, ItemPartNested, Repository } from '@/types/backoffice';
 import { useModelLabels } from '@/contexts/model-labels-context';
 
 interface CurrentLocationSectionProps {
@@ -68,11 +69,7 @@ function SetupLocationPrompt({ historicalItemId }: { historicalItemId: number })
     enabled: !!token,
   });
 
-  const repositories: Repository[] = !repositoriesData
-    ? []
-    : Array.isArray(repositoriesData)
-      ? repositoriesData
-      : repositoriesData.results;
+  const repositories: Repository[] = repositoriesData ?? [];
 
   const [saving, setSaving] = useState(false);
 
@@ -80,12 +77,16 @@ function SetupLocationPrompt({ historicalItemId }: { historicalItemId: number })
     if (!token || !repository || !shelfmark.trim()) return;
     setSaving(true);
     try {
-      const existingItems = await getCurrentItems(token, {
-        repository: Number(repository),
-        limit: 500,
-      });
+      // Walk all pages — `limit: 500` was silently capped at DRF's
+      // max_limit (100), so a heavily-curated repository's late current_items
+      // would be missed by the find-match step and we'd create a duplicate
+      // `(repository, shelfmark)` row.
+      const existingItems = await walkPaginated<CurrentItemOption>(
+        `/api/v1/manuscripts/management/current-items/?repository=${Number(repository)}&limit=100`,
+        (path) => authFetch(path, token)
+      );
       let currentItemId: number;
-      const match = existingItems.results.find(
+      const match = existingItems.find(
         (ci) => ci.shelfmark.toLowerCase() === shelfmark.trim().toLowerCase()
       );
       if (match) {

--- a/components/backoffice/notifications-popover.test.tsx
+++ b/components/backoffice/notifications-popover.test.tsx
@@ -1,0 +1,148 @@
+/** @vitest-environment jsdom */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NotificationsPopover } from './notifications-popover';
+import type { Notification } from '@/lib/backoffice/pending-notifications';
+
+const NOW = 1_700_000_000_000;
+
+function n(overrides: Partial<Notification>): Notification {
+  return {
+    id: 'n1',
+    kind: 'review-assigned',
+    createdAt: NOW - 60_000,
+    readAt: null,
+    ...overrides,
+  };
+}
+
+const SAMPLE: Notification[] = [
+  n({ id: 'a', kind: 'review-assigned' }),
+  n({ id: 'b', kind: 'comment-reply' }),
+  n({ id: 'c', kind: 'mention', readAt: NOW - 30_000 }),
+];
+
+describe('<NotificationsPopover>', () => {
+  it('renders an empty-state copy when there are no notifications', () => {
+    render(
+      <NotificationsPopover
+        notifications={[]}
+        onMarkAllRead={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    expect(screen.getByText(/all caught up/i)).toBeTruthy();
+  });
+
+  it('shows the unread count in the header', () => {
+    render(
+      <NotificationsPopover
+        notifications={SAMPLE}
+        onMarkAllRead={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    // 2 unread (a, b) — c is read.
+    expect(screen.getByText(/2 unread/i)).toBeTruthy();
+  });
+
+  it('groups notifications by kind', () => {
+    const { container } = render(
+      <NotificationsPopover
+        notifications={SAMPLE}
+        onMarkAllRead={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    const groups = container.querySelectorAll('[data-notification-kind]');
+    const kinds = Array.from(groups).map((g) => g.getAttribute('data-notification-kind'));
+    expect(kinds).toContain('review-assigned');
+    expect(kinds).toContain('comment-reply');
+    expect(kinds).toContain('mention');
+  });
+
+  it('clicking a row fires onSelect with the notification', () => {
+    const onSelect = vi.fn();
+    const { container } = render(
+      <NotificationsPopover
+        notifications={SAMPLE}
+        onMarkAllRead={vi.fn()}
+        onSelect={onSelect}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    const row = container.querySelector('[data-notification-id="a"]') as HTMLElement;
+    fireEvent.click(row);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].id).toBe('a');
+  });
+
+  it('mark-all-read fires onMarkAllRead', () => {
+    const onMarkAllRead = vi.fn();
+    render(
+      <NotificationsPopover
+        notifications={SAMPLE}
+        onMarkAllRead={onMarkAllRead}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /mark all as read/i }));
+    expect(onMarkAllRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('mark-all-read is disabled when nothing is unread', () => {
+    render(
+      <NotificationsPopover
+        notifications={[n({ readAt: NOW })]}
+        onMarkAllRead={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    expect(screen.getByRole('button', { name: /mark all as read/i }).hasAttribute('disabled')).toBe(
+      true
+    );
+  });
+
+  it('paints unread rows differently from read rows', () => {
+    const { container } = render(
+      <NotificationsPopover
+        notifications={SAMPLE}
+        onMarkAllRead={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+        now={NOW}
+      />
+    );
+    const unread = container.querySelector('[data-notification-id="a"]') as HTMLElement;
+    const read = container.querySelector('[data-notification-id="c"]') as HTMLElement;
+    expect(unread.dataset.read).toBe('false');
+    expect(read.dataset.read).toBe('true');
+  });
+
+  it('close button fires onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <NotificationsPopover
+        notifications={SAMPLE}
+        onMarkAllRead={vi.fn()}
+        onSelect={vi.fn()}
+        onClose={onClose}
+        now={NOW}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /close notifications/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/backoffice/notifications-popover.tsx
+++ b/components/backoffice/notifications-popover.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+/**
+ * Phase 7.1 of ROADMAP-EDITORS-V2 — backoffice notifications popover.
+ *
+ * Header bell opens this; content groups the cycle-232 notifications
+ * by kind and surfaces an aggregate "N unread" count plus a "Mark all
+ * as read" action. Each row is a click-target so the host can route
+ * the user to the relevant page (review queue, comment thread,
+ * mentioned span).
+ *
+ * Presentational only — `onMarkAllRead`, `onSelect`, `onClose` lift
+ * state to the host.
+ */
+
+import * as React from 'react';
+import { AtSign, Bell, ClipboardCheck, MessageSquare, X } from 'lucide-react';
+
+import {
+  groupByKind,
+  unreadCount,
+  type Notification,
+  type NotificationKind,
+} from '@/lib/backoffice/pending-notifications';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+// Inlined here so this PR doesn't pull in the editor's draft-history
+// module just for the relative-time formatter.
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+function describeSnapshotAge(timestamp: number, now: number = Date.now()): string {
+  const delta = Math.max(0, now - timestamp);
+  if (delta < SECOND) return 'just now';
+  if (delta < MINUTE) return `${Math.floor(delta / SECOND)}s ago`;
+  if (delta < HOUR) return `${Math.floor(delta / MINUTE)}m ago`;
+  if (delta < DAY) return `${Math.floor(delta / HOUR)}h ago`;
+  return `${Math.floor(delta / DAY)}d ago`;
+}
+
+const KIND_LABEL: Record<NotificationKind, string> = {
+  'review-assigned': 'Assigned reviews',
+  'comment-reply': 'Comment replies',
+  mention: 'Mentions',
+};
+
+const KIND_ICON: Record<NotificationKind, React.ComponentType<{ className?: string }>> = {
+  'review-assigned': ClipboardCheck,
+  'comment-reply': MessageSquare,
+  mention: AtSign,
+};
+
+const KIND_ORDER: NotificationKind[] = ['review-assigned', 'comment-reply', 'mention'];
+
+export interface NotificationsPopoverProps {
+  notifications: Notification[];
+  onMarkAllRead: () => void;
+  onSelect: (notification: Notification) => void;
+  onClose: () => void;
+  /** Override "now" for stable tests. */
+  now?: number;
+  className?: string;
+}
+
+interface RowProps {
+  notification: Notification;
+  onSelect: (n: Notification) => void;
+  now?: number;
+}
+
+function NotificationRow({ notification, onSelect, now }: RowProps) {
+  const Icon = KIND_ICON[notification.kind];
+  const read = notification.readAt !== null;
+  return (
+    <li>
+      <button
+        type="button"
+        data-notification-id={notification.id}
+        data-read={read}
+        onClick={() => onSelect(notification)}
+        className={cn(
+          'flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors',
+          read ? 'opacity-70 hover:bg-muted/30' : 'hover:bg-muted/40'
+        )}
+      >
+        <span
+          aria-hidden
+          className={cn(
+            'mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full',
+            read
+              ? 'bg-muted text-muted-foreground'
+              : 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100'
+          )}
+        >
+          <Icon className="h-3 w-3" />
+        </span>
+        <span className="flex-1 truncate">{KIND_LABEL[notification.kind]}</span>
+        <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+          {describeSnapshotAge(notification.createdAt, now)}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+export function NotificationsPopover({
+  notifications,
+  onMarkAllRead,
+  onSelect,
+  onClose,
+  now,
+  className,
+}: NotificationsPopoverProps) {
+  const unread = unreadCount(notifications);
+  const groups = groupByKind(notifications);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Notifications"
+      data-testid="notifications-popover"
+      className={cn(
+        'flex w-80 flex-col gap-2 rounded-md border bg-background p-2 shadow-lg',
+        className
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 border-b pb-1.5">
+        <div className="flex items-center gap-1.5">
+          <Bell className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {unread} unread
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-[10px]"
+            disabled={unread === 0}
+            onClick={onMarkAllRead}
+          >
+            Mark all as read
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={onClose}
+            aria-label="Close notifications"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {notifications.length === 0 ? (
+        <p className="px-2 py-4 text-center text-xs italic text-muted-foreground">
+          You&rsquo;re all caught up.
+        </p>
+      ) : (
+        <div className="flex max-h-80 flex-col gap-2 overflow-y-auto">
+          {KIND_ORDER.map((kind) => {
+            const items = groups[kind];
+            if (items.length === 0) return null;
+            return (
+              <section key={kind} data-notification-kind={kind}>
+                <h4 className="px-2 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {KIND_LABEL[kind]}
+                </h4>
+                <ul className="flex flex-col gap-0.5">
+                  {items.map((it) => (
+                    <NotificationRow key={it.id} notification={it} onSelect={onSelect} now={now} />
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/backoffice/quality-dashboard.tsx
+++ b/components/backoffice/quality-dashboard.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, RefreshCcw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/contexts/auth-context';
+import { fetchQualityDashboard } from '@/services/backoffice/quality-dashboard';
+
+export function QualityDashboard() {
+  const { token } = useAuth();
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: ['backoffice', 'quality-dashboard'],
+    queryFn: () => fetchQualityDashboard(token!),
+    enabled: !!token,
+    staleTime: 30_000,
+  });
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Data quality</h1>
+          {data && (
+            <p className="text-xs text-muted-foreground">
+              Generated {new Date(data.generated_at).toLocaleString()}
+            </p>
+          )}
+        </div>
+        <Button onClick={() => void refetch()} variant="outline" size="sm">
+          {isFetching ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCcw className="mr-2 h-4 w-4" />
+          )}
+          Refresh
+        </Button>
+      </header>
+
+      {error && <p className="text-sm text-destructive">Error: {(error as Error).message}</p>}
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {data?.cards.map((card) => (
+          <Card key={card.id}>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between text-base">
+                <span>{card.label}</span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                    card.count === 0
+                      ? 'bg-emerald-500/15 text-emerald-700'
+                      : 'bg-amber-500/15 text-amber-800'
+                  }`}
+                >
+                  {card.count}
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {card.sample.length === 0 ? (
+                <p className="text-sm text-muted-foreground">All clean.</p>
+              ) : (
+                <ul className="space-y-1 text-sm">
+                  {card.sample.map((row, i) => (
+                    <li key={i} className="font-mono text-xs">
+                      {JSON.stringify(row)}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/backoffice/review-age-badge.test.tsx
+++ b/components/backoffice/review-age-badge.test.tsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ReviewAgeBadge } from './review-age-badge';
+import type { ReviewQueueItem } from '@/lib/backoffice/review-queue-sla';
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+function item(overrides: Partial<ReviewQueueItem>): ReviewQueueItem {
+  return {
+    id: 1,
+    status: 'review',
+    enteredReviewAt: NOW - 2 * DAY,
+    assignedTo: null,
+    ...overrides,
+  };
+}
+
+describe('<ReviewAgeBadge>', () => {
+  it('renders the formatted age and a severity attribute', () => {
+    const { container } = render(
+      <ReviewAgeBadge item={item({ enteredReviewAt: NOW - 4 * DAY })} now={NOW} />
+    );
+    expect(screen.getByText(/4d/)).toBeTruthy();
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.dataset.severity).toBe('warning');
+  });
+
+  it('emits "fresh" for items under the warning threshold', () => {
+    const { container } = render(
+      <ReviewAgeBadge item={item({ enteredReviewAt: NOW - DAY })} now={NOW} />
+    );
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.dataset.severity).toBe('fresh');
+  });
+
+  it('emits "overdue" past the overdue threshold', () => {
+    const { container } = render(
+      <ReviewAgeBadge item={item({ enteredReviewAt: NOW - 10 * DAY })} now={NOW} />
+    );
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.dataset.severity).toBe('overdue');
+  });
+
+  it('renders nothing for non-review items', () => {
+    const { container } = render(
+      <ReviewAgeBadge item={item({ status: 'draft', enteredReviewAt: null })} now={NOW} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('uses the current time when `now` is omitted', () => {
+    // We can't pin Date.now without test helpers here, but rendering
+    // shouldn't throw.
+    expect(() =>
+      render(<ReviewAgeBadge item={item({ enteredReviewAt: Date.now() - DAY })} />)
+    ).not.toThrow();
+  });
+});

--- a/components/backoffice/review-age-badge.tsx
+++ b/components/backoffice/review-age-badge.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * Phase 7.1 of ROADMAP-EDITORS-V2 — review-queue age badge.
+ *
+ * One row chip per queue item showing how long it's been waiting on a
+ * reviewer, tinted by SLA severity (fresh / warning / overdue). Drives
+ * off the cycle-212 helpers — pure data → `data-severity` data
+ * attribute → tailwind colour.
+ *
+ * Renders nothing for items not currently in review so the column
+ * stays narrow.
+ */
+
+import * as React from 'react';
+import { Clock } from 'lucide-react';
+
+import {
+  ageInReviewMs,
+  formatReviewAge,
+  slaSeverity,
+  type ReviewQueueItem,
+} from '@/lib/backoffice/review-queue-sla';
+import { cn } from '@/lib/utils';
+
+const SEVERITY_CLASS = {
+  fresh: 'border-muted bg-background text-muted-foreground',
+  warning:
+    'border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-700/50 dark:bg-amber-900/40 dark:text-amber-100',
+  overdue:
+    'border-rose-300 bg-rose-100 text-rose-900 dark:border-rose-700/50 dark:bg-rose-900/40 dark:text-rose-100',
+};
+
+export interface ReviewAgeBadgeProps {
+  item: ReviewQueueItem;
+  /** Override "now" for stable tests / time-travel views. */
+  now?: number;
+  className?: string;
+}
+
+export function ReviewAgeBadge({ item, now, className }: ReviewAgeBadgeProps) {
+  const age = ageInReviewMs(item, now);
+  if (age === null) return null;
+  const severity = slaSeverity(age);
+
+  return (
+    <span
+      data-severity={severity}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] tabular-nums',
+        SEVERITY_CLASS[severity],
+        className
+      )}
+      title={`In review for ${formatReviewAge(age)}`}
+    >
+      <Clock aria-hidden className="h-2.5 w-2.5" />
+      {formatReviewAge(age)}
+    </span>
+  );
+}

--- a/hooks/backoffice/use-autosave.ts
+++ b/hooks/backoffice/use-autosave.ts
@@ -9,6 +9,22 @@ interface AutosaveData<T> {
   savedAt: number;
 }
 
+// Validate a parsed value matches the AutosaveData<T> shape: a plain
+// object carrying both `data` and a numeric `savedAt`. `'null'`, arrays,
+// and old-format objects without these keys would otherwise leak undefined
+// into callers — the editor's recovery prompt would offer to restore a
+// draft that doesn't actually exist. Module-scope so its identity is
+// stable across renders (the hook's useCallbacks don't need it in deps).
+function isAutosavePayload(value: unknown): value is { data: unknown; savedAt: number } {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    'data' in value &&
+    typeof (value as { savedAt?: unknown }).savedAt === 'number'
+  );
+}
+
 /**
  * Autosave hook that periodically saves form data to localStorage.
  *
@@ -57,13 +73,24 @@ export function useAutosave<T>(key: string, data: T, dirty: boolean, intervalMs 
     }
 
     setStatus('idle');
+    // Track the inner "Saving..." → save() timer so cleanup cancels it.
+    // Without this, a manual server save (which flips dirty back to false
+    // and triggers cleanup) could race with an in-flight 300ms timer and
+    // write a stale localStorage draft after the cleanup ran — the next
+    // page load would then offer recovery for an already-saved record.
+    let pendingSaveTimer: ReturnType<typeof setTimeout> | null = null;
     const timer = setInterval(() => {
       setStatus('saving');
-      // Small delay so the "Saving..." text is visible
-      setTimeout(() => save(), 300);
+      pendingSaveTimer = setTimeout(() => {
+        pendingSaveTimer = null;
+        save();
+      }, 300);
     }, intervalMs);
 
-    return () => clearInterval(timer);
+    return () => {
+      clearInterval(timer);
+      if (pendingSaveTimer !== null) clearTimeout(pendingSaveTimer);
+    };
   }, [dirty, intervalMs, save]);
 
   // Recover saved draft
@@ -71,8 +98,8 @@ export function useAutosave<T>(key: string, data: T, dirty: boolean, intervalMs 
     try {
       const raw = localStorage.getItem(storageKey);
       if (!raw) return null;
-      const parsed: AutosaveData<T> = JSON.parse(raw);
-      return parsed.data;
+      const parsed: unknown = JSON.parse(raw);
+      return isAutosavePayload(parsed) ? (parsed.data as T) : null;
     } catch {
       return null;
     }
@@ -83,7 +110,8 @@ export function useAutosave<T>(key: string, data: T, dirty: boolean, intervalMs 
     try {
       const raw = localStorage.getItem(storageKey);
       if (!raw) return { exists: false, savedAt: null };
-      const parsed: AutosaveData<T> = JSON.parse(raw);
+      const parsed: unknown = JSON.parse(raw);
+      if (!isAutosavePayload(parsed)) return { exists: false, savedAt: null };
       return { exists: true, savedAt: parsed.savedAt };
     } catch {
       return { exists: false, savedAt: null };

--- a/hooks/backoffice/use-keyboard-shortcut.test.tsx
+++ b/hooks/backoffice/use-keyboard-shortcut.test.tsx
@@ -1,0 +1,94 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useKeyboardShortcut } from './use-keyboard-shortcut';
+
+function Mount({
+  combo,
+  handler,
+  enabled = true,
+}: {
+  combo: string;
+  handler: (e: KeyboardEvent) => void;
+  enabled?: boolean;
+}) {
+  useKeyboardShortcut(combo, handler, enabled);
+  return null;
+}
+
+function fireKeyDown(init: KeyboardEventInit & { key: string }) {
+  const event = new KeyboardEvent('keydown', { ...init, bubbles: true, cancelable: true });
+  document.dispatchEvent(event);
+}
+
+describe('useKeyboardShortcut', () => {
+  it('fires on the matching key combo', () => {
+    const handler = vi.fn();
+    render(<Mount combo="mod+s" handler={handler} />);
+    fireKeyDown({ key: 's', metaKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires for both Cmd (metaKey) and Ctrl (ctrlKey) under "mod"', () => {
+    const handler = vi.fn();
+    render(<Mount combo="mod+s" handler={handler} />);
+    fireKeyDown({ key: 's', ctrlKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire when Shift is also held but combo only specifies mod+s', () => {
+    // Regression net: native macOS "Save As" is Cmd+Shift+S. Without exact
+    // modifier matching, the app's mod+s shortcut would steal that combo.
+    const handler = vi.fn();
+    render(<Mount combo="mod+s" handler={handler} />);
+    fireKeyDown({ key: 's', metaKey: true, shiftKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when Alt is also held but combo only specifies mod+s', () => {
+    const handler = vi.fn();
+    render(<Mount combo="mod+s" handler={handler} />);
+    fireKeyDown({ key: 's', metaKey: true, altKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('fires on `mod+shift+s` when Cmd+Shift+S is pressed (combo explicitly includes shift)', () => {
+    const handler = vi.fn();
+    render(<Mount combo="mod+shift+s" handler={handler} />);
+    fireKeyDown({ key: 's', metaKey: true, shiftKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire on the bare key when the combo requires a modifier', () => {
+    const handler = vi.fn();
+    render(<Mount combo="mod+s" handler={handler} />);
+    fireKeyDown({ key: 's' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire on a modifier+key when the combo expects no modifier', () => {
+    const handler = vi.fn();
+    render(<Mount combo="escape" handler={handler} />);
+    fireKeyDown({ key: 'Escape', metaKey: true });
+    expect(handler).not.toHaveBeenCalled();
+    fireKeyDown({ key: 'Escape' });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects the enabled flag', () => {
+    const handler = vi.fn();
+    render(<Mount combo="mod+s" handler={handler} enabled={false} />);
+    fireKeyDown({ key: 's', metaKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest handler reference (refresh-on-render via ref)', () => {
+    const old = vi.fn();
+    const next = vi.fn();
+    const { rerender } = render(<Mount combo="mod+s" handler={old} />);
+    rerender(<Mount combo="mod+s" handler={next} />);
+    fireKeyDown({ key: 's', metaKey: true });
+    expect(old).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/backoffice/use-keyboard-shortcut.ts
+++ b/hooks/backoffice/use-keyboard-shortcut.ts
@@ -32,10 +32,14 @@ export function useKeyboardShortcut(combo: string, handler: ShortcutHandler, ena
     const key = parts.filter((p) => p !== 'mod' && p !== 'shift' && p !== 'alt')[0];
 
     function onKeyDown(e: KeyboardEvent) {
+      // Require exact modifier match: every flag the combo specifies must
+      // be pressed AND every flag it doesn't specify must NOT be pressed.
+      // Without the second half, `mod+s` would fire on Cmd+Shift+S (which
+      // collides with the native macOS "Save As") and on Cmd+Alt+S.
       const mod = e.metaKey || e.ctrlKey;
-      if (needMod && !mod) return;
-      if (needShift && !e.shiftKey) return;
-      if (needAlt && !e.altKey) return;
+      if (needMod !== mod) return;
+      if (needShift !== e.shiftKey) return;
+      if (needAlt !== e.altKey) return;
 
       // Match the key
       const eventKey = e.key.toLowerCase();

--- a/hooks/backoffice/use-recent-entities.test.tsx
+++ b/hooks/backoffice/use-recent-entities.test.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// jsdom in this project doesn't ship Storage; install a shim.
+function installStorageShim() {
+  const store = new Map<string, string>();
+  const shim: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+  };
+  Object.defineProperty(window, 'localStorage', {
+    value: shim,
+    configurable: true,
+    writable: true,
+  });
+}
+
+installStorageShim();
+
+import { useRecentEntities } from './use-recent-entities';
+
+const STORAGE_KEY = 'backoffice:recent-entities';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('useRecentEntities', () => {
+  it('starts empty when storage is empty', () => {
+    const { result } = renderHook(() => useRecentEntities());
+    expect(result.current.entities).toEqual([]);
+  });
+
+  it('returns the prepopulated list (newest first) on mount', () => {
+    const list = [
+      { label: 'A', href: '/a', type: 'manuscript', visitedAt: 2 },
+      { label: 'B', href: '/b', type: 'scribe', visitedAt: 1 },
+    ];
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+    const { result } = renderHook(() => useRecentEntities());
+    expect(result.current.entities).toEqual(list);
+  });
+
+  it('does NOT throw when storage holds malformed JSON — returns []', () => {
+    // Regression net for the fix: getSnapshot() used to call JSON.parse
+    // unguarded, which would throw on every backoffice render.
+    window.localStorage.setItem(STORAGE_KEY, '{not json');
+    const { result } = renderHook(() => useRecentEntities());
+    expect(result.current.entities).toEqual([]);
+  });
+
+  it('does NOT throw when storage holds valid JSON that is not an array', () => {
+    // `'null'`, `'{}'`, scalars: parsed cleanly by JSON.parse but the
+    // result wasn't an array. Used to flow into `.filter` / `.find`
+    // downstream and crash. The Array.isArray guard normalizes to [].
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: 'bar' }));
+    const { result } = renderHook(() => useRecentEntities());
+    expect(result.current.entities).toEqual([]);
+  });
+
+  it('drops malformed entries from a valid array (shape validation)', () => {
+    // A list with one good entry and one malformed entry (older format,
+    // partial-write corruption). The dashboard called `e.href.startsWith(...)`
+    // on the malformed entry and crashed; per-item validation now filters
+    // bad entries while keeping the good ones.
+    const list = [
+      { label: 'Good', href: '/good', type: 'manuscript', visitedAt: 1 },
+      { foo: 'bar' }, // missing every required field
+      { label: 'Also good', href: '/also', type: 'scribe', visitedAt: 2 },
+      { label: 'Number visitedAt please', href: '/x', type: 'graph', visitedAt: 'oops' },
+    ];
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+    const { result } = renderHook(() => useRecentEntities());
+    expect(result.current.entities.map((e) => e.href)).toEqual(['/good', '/also']);
+  });
+
+  it('track() prepends an entry with visitedAt', () => {
+    const { result } = renderHook(() => useRecentEntities());
+    act(() => result.current.track({ label: 'A', href: '/a', type: 'manuscript' }));
+    expect(result.current.entities).toHaveLength(1);
+    expect(result.current.entities[0]!.label).toBe('A');
+    expect(typeof result.current.entities[0]!.visitedAt).toBe('number');
+  });
+
+  it('track() dedupes by href, moving the entry to the top', () => {
+    const { result } = renderHook(() => useRecentEntities());
+    act(() => {
+      result.current.track({ label: 'A', href: '/a', type: 'manuscript' });
+      result.current.track({ label: 'B', href: '/b', type: 'scribe' });
+      result.current.track({ label: 'A2', href: '/a', type: 'manuscript' });
+    });
+    const hrefs = result.current.entities.map((e) => e.href);
+    expect(hrefs).toEqual(['/a', '/b']);
+    // The label was updated on the deduped entry, and it's at the top.
+    expect(result.current.entities[0]!.label).toBe('A2');
+  });
+
+  it('track() caps the list at 15 entries (newest kept)', () => {
+    const { result } = renderHook(() => useRecentEntities());
+    act(() => {
+      for (let i = 0; i < 20; i++) {
+        result.current.track({ label: `e${i}`, href: `/e/${i}`, type: 'manuscript' });
+      }
+    });
+    expect(result.current.entities).toHaveLength(15);
+    expect(result.current.entities[0]!.href).toBe('/e/19');
+    expect(result.current.entities[14]!.href).toBe('/e/5');
+  });
+});

--- a/hooks/backoffice/use-recent-entities.ts
+++ b/hooks/backoffice/use-recent-entities.ts
@@ -27,10 +27,28 @@ function emitChange() {
   for (const listener of listeners) listener();
 }
 
+function isValidRecentEntity(value: unknown): value is RecentEntity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const v = value as Partial<RecentEntity>;
+  return (
+    typeof v.label === 'string' &&
+    typeof v.href === 'string' &&
+    typeof v.type === 'string' &&
+    typeof v.visitedAt === 'number'
+  );
+}
+
 function readFromStorage(): RecentEntity[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    // Guard against `'null'`, scalars, or `'{...}'` in storage — older
+    // clients or hand-edited values that would otherwise crash every
+    // downstream `.filter` / `.find` on the result. Per-item validation
+    // protects `e.href.startsWith(...)` calls in the dashboard from
+    // partially-malformed entries inside an otherwise-valid array.
+    return Array.isArray(parsed) ? parsed.filter(isValidRecentEntity) : [];
   } catch {
     return [];
   }
@@ -41,7 +59,19 @@ function getSnapshot(): RecentEntity[] {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (raw === cachedRaw) return cachedSnapshot;
   cachedRaw = raw;
-  cachedSnapshot = raw ? JSON.parse(raw) : [];
+  // Guard against corrupted / manually-edited localStorage. Without this,
+  // a malformed value would throw on every backoffice render via
+  // useSyncExternalStore.
+  try {
+    if (!raw) {
+      cachedSnapshot = [];
+    } else {
+      const parsed = JSON.parse(raw);
+      cachedSnapshot = Array.isArray(parsed) ? parsed.filter(isValidRecentEntity) : [];
+    }
+  } catch {
+    cachedSnapshot = [];
+  }
   return cachedSnapshot;
 }
 

--- a/hooks/backoffice/use-unsaved-guard.test.tsx
+++ b/hooks/backoffice/use-unsaved-guard.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+import { useUnsavedGuard } from './use-unsaved-guard';
+
+function makeBeforeUnloadEvent(): BeforeUnloadEvent {
+  // jsdom ships an Event constructor but no BeforeUnloadEvent. The handler
+  // only touches preventDefault() and the returnValue setter, so a plain
+  // Event with a writable returnValue is enough.
+  const ev = new Event('beforeunload') as unknown as BeforeUnloadEvent & {
+    returnValue: string;
+  };
+  Object.defineProperty(ev, 'returnValue', { value: 'untouched', writable: true });
+  return ev;
+}
+
+describe('useUnsavedGuard beforeunload handler', () => {
+  beforeEach(() => {
+    // Make sure each test starts with a clean window state.
+    window.history.pushState(null, '', '/');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('attaches a beforeunload handler when dirty is true', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    renderHook(() => useUnsavedGuard(true));
+    const calls = addSpy.mock.calls.map(([type]) => type);
+    expect(calls).toContain('beforeunload');
+  });
+
+  it('does NOT attach the beforeunload handler when dirty is false', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    renderHook(() => useUnsavedGuard(false));
+    const calls = addSpy.mock.calls.map(([type]) => type);
+    expect(calls).not.toContain('beforeunload');
+  });
+
+  it('preventDefault AND sets returnValue so Safari/older Chrome surface the dialog', () => {
+    // The earlier handler only called preventDefault(). Safari and Chrome
+    // <120 ignore that — they require `returnValue` to be set to a string
+    // before the leave-page dialog appears. The fix sets both.
+    renderHook(() => useUnsavedGuard(true));
+    const ev = makeBeforeUnloadEvent();
+    const preventDefaultSpy = vi.spyOn(ev, 'preventDefault');
+    window.dispatchEvent(ev);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(ev.returnValue).toBe('');
+  });
+
+  it('removes the beforeunload handler on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useUnsavedGuard(true));
+    unmount();
+    const calls = removeSpy.mock.calls.map(([type]) => type);
+    expect(calls).toContain('beforeunload');
+  });
+});

--- a/hooks/backoffice/use-unsaved-guard.ts
+++ b/hooks/backoffice/use-unsaved-guard.ts
@@ -20,7 +20,12 @@ export function useUnsavedGuard(dirty: boolean) {
     if (!dirty) return;
 
     function handler(e: BeforeUnloadEvent) {
+      // Modern Chrome/Firefox honor preventDefault() alone, but Safari and
+      // Chrome <120 still require setting `returnValue` to actually surface
+      // the leave-page dialog. Set both so the guard works cross-browser
+      // and unsaved publication/manuscript edits aren't silently lost.
       e.preventDefault();
+      e.returnValue = '';
     }
 
     window.addEventListener('beforeunload', handler);

--- a/lib/backoffice-urls.test.ts
+++ b/lib/backoffice-urls.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { backofficeUrlFor, type BackofficeKind } from './backoffice-urls';
+
+describe('backofficeUrlFor', () => {
+  it('routes manuscript and item-part to the same URL pattern', () => {
+    // ItemPart and Manuscript are the same row in the backoffice — the
+    // alias is intentional. Lock both branches in.
+    expect(backofficeUrlFor('manuscript', 42)).toBe('/backoffice/manuscripts/42');
+    expect(backofficeUrlFor('item-part', 42)).toBe('/backoffice/manuscripts/42');
+  });
+
+  it('routes scribe / hand / publication to their own admin sections', () => {
+    expect(backofficeUrlFor('scribe', 7)).toBe('/backoffice/scribes/7');
+    expect(backofficeUrlFor('hand', 7)).toBe('/backoffice/hands/7');
+    expect(backofficeUrlFor('publication', 7)).toBe('/backoffice/publications/7');
+  });
+
+  it('accepts string ids verbatim (used for slugs / non-numeric pks)', () => {
+    expect(backofficeUrlFor('publication', 'my-post')).toBe('/backoffice/publications/my-post');
+  });
+
+  it('handles every documented BackofficeKind exhaustively', () => {
+    const kinds: BackofficeKind[] = ['manuscript', 'item-part', 'scribe', 'hand', 'publication'];
+    for (const k of kinds) {
+      const url = backofficeUrlFor(k, 1);
+      expect(url.startsWith('/backoffice/')).toBe(true);
+      expect(url.endsWith('/1')).toBe(true);
+    }
+  });
+});

--- a/lib/backoffice/bulk-action.test.ts
+++ b/lib/backoffice/bulk-action.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+import { runBulkAction } from './bulk-action';
+
+const toastMocks = toast as unknown as {
+  success: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  warning: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  toastMocks.success.mockReset();
+  toastMocks.error.mockReset();
+  toastMocks.warning.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('runBulkAction', () => {
+  it('toasts success and invalidates when every action resolves', async () => {
+    const invalidate = vi.fn();
+    const action = vi.fn().mockResolvedValue(undefined);
+    const result = await runBulkAction({
+      ids: [1, 2, 3],
+      action,
+      invalidate,
+      pastTense: 'deleted',
+      noun: 'comment',
+    });
+    expect(result).toEqual({ succeeded: 3, failed: 0 });
+    expect(action).toHaveBeenCalledTimes(3);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(toastMocks.success).toHaveBeenCalledWith('3 comments deleted');
+    expect(toastMocks.warning).not.toHaveBeenCalled();
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
+  it('still invalidates when ALL actions reject — partial successes used to be lost', async () => {
+    // The original `Promise.all` short-circuit dropped the invalidate step.
+    // The fix is unconditional invalidation, even on total failure (the
+    // server may still have committed something the user needs to see).
+    const invalidate = vi.fn();
+    const action = vi.fn().mockRejectedValue(new Error('boom'));
+    const result = await runBulkAction({
+      ids: [1, 2],
+      action,
+      invalidate,
+      pastTense: 'deleted',
+      noun: 'user',
+    });
+    expect(result).toEqual({ succeeded: 0, failed: 2 });
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(toastMocks.error).toHaveBeenCalledWith('Failed to update users');
+  });
+
+  it('toasts a partial-success warning when only some reject', async () => {
+    const invalidate = vi.fn();
+    const action = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+    const result = await runBulkAction({
+      ids: [1, 2, 3],
+      action,
+      invalidate,
+      pastTense: 'activated',
+      noun: 'user',
+    });
+    expect(result).toEqual({ succeeded: 2, failed: 1 });
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(toastMocks.warning).toHaveBeenCalledWith('2 activated, 1 failed');
+  });
+
+  it('uses the singular noun when there is only one id', async () => {
+    const invalidate = vi.fn();
+    await runBulkAction({
+      ids: [1],
+      action: () => Promise.resolve(),
+      invalidate,
+      pastTense: 'deleted',
+      noun: 'annotation',
+    });
+    expect(toastMocks.success).toHaveBeenCalledWith('1 annotation deleted');
+  });
+});

--- a/lib/backoffice/bulk-action.ts
+++ b/lib/backoffice/bulk-action.ts
@@ -1,0 +1,39 @@
+import { toast } from 'sonner';
+
+/**
+ * Run a bulk action across many ids, ALWAYS invalidate the cache afterwards
+ * (so partial successes show up in the UI), and toast the right outcome.
+ *
+ * The naive `await Promise.all(ids.map(fn))` pattern in the backoffice was
+ * dropping cache invalidation on any failure — successes still committed
+ * server-side but the table kept showing stale rows. `allSettled` + an
+ * unconditional invalidate is the fix; this helper centralizes that.
+ */
+export async function runBulkAction<TId>(options: {
+  ids: TId[];
+  action: (id: TId) => Promise<unknown>;
+  invalidate: () => void;
+  /** Past-tense verb for the success toast: "deleted", "approved", "activated". */
+  pastTense: string;
+  /** Singular noun for the toast: "user", "annotation", "comment". */
+  noun: string;
+}): Promise<{ succeeded: number; failed: number }> {
+  const { ids, action, invalidate, pastTense, noun } = options;
+  const results = await Promise.allSettled(ids.map((id) => action(id)));
+  invalidate();
+
+  const failed = results.filter((r) => r.status === 'rejected').length;
+  const total = ids.length;
+  const succeeded = total - failed;
+  const plural = total === 1 ? noun : `${noun}s`;
+
+  if (failed === 0) {
+    toast.success(`${total} ${plural} ${pastTense}`);
+  } else if (failed === total) {
+    toast.error(`Failed to update ${plural}`);
+  } else {
+    toast.warning(`${succeeded} ${pastTense}, ${failed} failed`);
+  }
+
+  return { succeeded, failed };
+}

--- a/lib/backoffice/csv-escape.test.ts
+++ b/lib/backoffice/csv-escape.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeCsvField } from './csv-escape';
+
+describe('escapeCsvField', () => {
+  it('passes through plain text untouched', () => {
+    expect(escapeCsvField('hello world')).toBe('hello world');
+    expect(escapeCsvField('Add. 1234')).toBe('Add. 1234');
+  });
+
+  it('quotes when the field contains a comma', () => {
+    expect(escapeCsvField('a, b')).toBe('"a, b"');
+  });
+
+  it('quotes and escapes embedded double quotes', () => {
+    expect(escapeCsvField('a "b" c')).toBe('"a ""b"" c"');
+  });
+
+  it('quotes when the field contains a newline OR a carriage return', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+    expect(escapeCsvField('split\rhere')).toBe('"split\rhere"');
+  });
+
+  it('neutralizes formula-injection prefixes by inserting a leading single quote', () => {
+    // OWASP CSV-injection: a malicious description like `=HYPERLINK(...)` or
+    // `+cmd|...` would execute as a formula when opened in Excel/Sheets.
+    expect(escapeCsvField('=HYPERLINK("evil")')).toBe(`"'=HYPERLINK(""evil"")"`);
+    expect(escapeCsvField('+1+1')).toBe(`'+1+1`);
+    expect(escapeCsvField('-1')).toBe(`'-1`);
+    expect(escapeCsvField('@SUM(A1)')).toBe(`'@SUM(A1)`);
+    // Tab gets the prefix but isn't a CSV-structural character, so the cell
+    // stays unquoted.
+    expect(escapeCsvField('\tTab')).toBe(`'\tTab`);
+    // CR is structural, so the CR-prefixed cell DOES quote.
+    expect(escapeCsvField('\rCR')).toBe(`"'\rCR"`);
+  });
+
+  it('does NOT prefix safe characters that resemble formulas mid-string', () => {
+    expect(escapeCsvField('1+1=2')).toBe('1+1=2');
+    expect(escapeCsvField('foo@bar')).toBe('foo@bar');
+  });
+});

--- a/lib/backoffice/csv-escape.ts
+++ b/lib/backoffice/csv-escape.ts
@@ -1,0 +1,22 @@
+/**
+ * Escape a single CSV field, neutralizing both structural breakage AND
+ * Excel/Sheets/Numbers formula injection (OWASP CSV_Injection).
+ *
+ * Used by the search-results CSV export and the backoffice data-table
+ * export. Fields like `description`, `name`, `place`, `shelfmark` carry
+ * user input from upstream records, so a malicious row could exfiltrate
+ * data on open without this guard.
+ */
+
+// Excel/Sheets/Numbers interpret a leading `=`, `+`, `-`, `@`, tab, or `\r`
+// as a formula. Prefix with a single quote to neutralize while keeping the
+// visible cell readable. https://owasp.org/www-community/attacks/CSV_Injection
+const FORMULA_PREFIX_PATTERN = /^[=+\-@\t\r]/;
+
+export function escapeCsvField(value: string): string {
+  const safe = FORMULA_PREFIX_PATTERN.test(value) ? `'${value}` : value;
+  if (safe.includes(',') || safe.includes('"') || safe.includes('\n') || safe.includes('\r')) {
+    return `"${safe.replace(/"/g, '""')}"`;
+  }
+  return safe;
+}

--- a/lib/backoffice/format-api-error.test.ts
+++ b/lib/backoffice/format-api-error.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { BackofficeApiError } from '@/services/backoffice/api-client';
+import { formatApiError } from './format-api-error';
+
+describe('formatApiError', () => {
+  it('returns the `detail` field directly when present', () => {
+    const err = new BackofficeApiError(404, { detail: 'Not found.' });
+    expect(formatApiError(err)).toBe('Not found.');
+  });
+
+  it('joins non_field_errors with ". " between entries', () => {
+    const err = new BackofficeApiError(400, {
+      non_field_errors: ['First problem.', 'Second problem.'],
+    });
+    expect(formatApiError(err)).toBe('First problem.. Second problem.');
+  });
+
+  it('formats DRF field-level array errors as `field: msg1, msg2`', () => {
+    const err = new BackofficeApiError(400, {
+      title: ['This field is required.'],
+      slug: ['Already exists.', 'Must be lowercase.'],
+    });
+    expect(formatApiError(err)).toBe(
+      'title: This field is required.. slug: Already exists., Must be lowercase.'
+    );
+  });
+
+  it('handles a string field value (non-array shape) as `field: value`', () => {
+    const err = new BackofficeApiError(400, { reason: 'Quota exceeded' });
+    expect(formatApiError(err)).toBe('reason: Quota exceeded');
+  });
+
+  it('falls back to "Server error (status)" when the body has no readable shape', () => {
+    const err = new BackofficeApiError(500, {});
+    expect(formatApiError(err)).toBe('Server error (500)');
+  });
+
+  it('falls back to "Server error" when body has only non-renderable values', () => {
+    // Numbers / objects / nested arrays aren't currently formatted.
+    const err = new BackofficeApiError(500, { code: 42, nested: { foo: 'bar' } });
+    expect(formatApiError(err)).toBe('Server error (500)');
+  });
+
+  it('uses Error.message for plain Errors', () => {
+    expect(formatApiError(new Error('boom'))).toBe('boom');
+    expect(formatApiError(new TypeError('bad type'))).toBe('bad type');
+  });
+
+  it('returns a generic message for unknown error shapes', () => {
+    expect(formatApiError(null)).toBe('An unexpected error occurred');
+    expect(formatApiError(undefined)).toBe('An unexpected error occurred');
+    expect(formatApiError('string error')).toBe('An unexpected error occurred');
+    expect(formatApiError(42)).toBe('An unexpected error occurred');
+    expect(formatApiError({ message: 'plain object' })).toBe('An unexpected error occurred');
+  });
+
+  it('prefers `detail` over field-level errors when both are present', () => {
+    const err = new BackofficeApiError(400, {
+      detail: 'Top-level reason.',
+      title: ['ignored'],
+    });
+    expect(formatApiError(err)).toBe('Top-level reason.');
+  });
+
+  it('prefers non_field_errors over field-level errors when both are present', () => {
+    const err = new BackofficeApiError(400, {
+      non_field_errors: ['Cross-field rule failed.'],
+      title: ['ignored'],
+    });
+    expect(formatApiError(err)).toBe('Cross-field rule failed.');
+  });
+});

--- a/lib/backoffice/pending-notifications.ts
+++ b/lib/backoffice/pending-notifications.ts
@@ -1,0 +1,79 @@
+/**
+ * Phase 7.1 of ROADMAP-EDITORS-V2 — pure things-waiting-on-me helper.
+ *
+ * The backoffice header gets a notification icon with a count of
+ * unread items: assigned reviews, comment replies you're tagged in,
+ * and direct @mentions. This module owns the pure counting and
+ * grouping; the API layer fetches notifications and keeps them in
+ * sync.
+ *
+ * Notifications are append-only: they're either unread (`readAt: null`)
+ * or read (timestamp of when the user dismissed them). `markAllRead`
+ * and `markKindRead` produce a new list with the appropriate stamps.
+ */
+
+export type NotificationKind = 'review-assigned' | 'comment-reply' | 'mention';
+
+export const NOTIFICATION_KINDS: NotificationKind[] = [
+  'review-assigned',
+  'comment-reply',
+  'mention',
+];
+
+export interface Notification {
+  id: string;
+  kind: NotificationKind;
+  /** ms epoch. */
+  createdAt: number;
+  /** ms epoch when the user dismissed this notification, or null when unread. */
+  readAt: number | null;
+}
+
+export function unreadCount(notifications: Notification[]): number {
+  let n = 0;
+  for (const x of notifications) if (x.readAt === null) n++;
+  return n;
+}
+
+export type UnreadByKind = Record<NotificationKind, number>;
+
+function emptyByKind<T>(value: T): Record<NotificationKind, T> {
+  return {
+    'review-assigned': value,
+    'comment-reply': value,
+    mention: value,
+  };
+}
+
+export function unreadByKind(notifications: Notification[]): UnreadByKind {
+  const out: UnreadByKind = emptyByKind(0);
+  for (const x of notifications) if (x.readAt === null) out[x.kind] += 1;
+  return out;
+}
+
+export function groupByKind(
+  notifications: Notification[]
+): Record<NotificationKind, Notification[]> {
+  const out: Record<NotificationKind, Notification[]> = emptyByKind<Notification[]>([]);
+  // emptyByKind shares array references, so re-create per kind:
+  for (const k of NOTIFICATION_KINDS) out[k] = [];
+  for (const x of notifications) out[x.kind].push(x);
+  return out;
+}
+
+export function markAllRead(
+  notifications: Notification[],
+  now: number = Date.now()
+): Notification[] {
+  return notifications.map((x) => (x.readAt === null ? { ...x, readAt: now } : x));
+}
+
+export function markKindRead(
+  notifications: Notification[],
+  kind: NotificationKind,
+  now: number = Date.now()
+): Notification[] {
+  return notifications.map((x) =>
+    x.kind === kind && x.readAt === null ? { ...x, readAt: now } : x
+  );
+}

--- a/lib/backoffice/query-keys.test.ts
+++ b/lib/backoffice/query-keys.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { backofficeKeys } from './query-keys';
+
+describe('backofficeKeys structure', () => {
+  it('namespaces every entity under the "backoffice" root', () => {
+    expect(backofficeKeys.all).toEqual(['backoffice']);
+    expect(backofficeKeys.manuscripts.all()[0]).toBe('backoffice');
+    expect(backofficeKeys.scribes.all()[0]).toBe('backoffice');
+    expect(backofficeKeys.publications.all()[0]).toBe('backoffice');
+    expect(backofficeKeys.users.all()[0]).toBe('backoffice');
+    expect(backofficeKeys.searchEngine.all()[0]).toBe('backoffice');
+  });
+
+  it('encodes the entity name as the second segment for `all()`', () => {
+    expect(backofficeKeys.manuscripts.all()).toEqual(['backoffice', 'manuscripts']);
+    expect(backofficeKeys.scribes.all()).toEqual(['backoffice', 'scribes']);
+    expect(backofficeKeys.publications.all()).toEqual(['backoffice', 'publications']);
+  });
+
+  it('list keys extend their entity-all() so invalidate(all) covers list', () => {
+    // Critical invariant — `queryClient.invalidateQueries({ queryKey: scribes.all() })`
+    // must invalidate `scribes.list()` and `scribes.detail(id)`. TanStack Query's
+    // partial-prefix matching depends on lists/details starting with the same
+    // tuple as `.all()`.
+    const all = backofficeKeys.scribes.all();
+    const list = backofficeKeys.scribes.list();
+    const detail = backofficeKeys.scribes.detail(7);
+    expect(list.slice(0, all.length)).toEqual([...all]);
+    expect(detail.slice(0, all.length)).toEqual([...all]);
+  });
+
+  it('manuscripts.list embeds filter object as the trailing segment', () => {
+    const filters = { offset: 20, type: 'charter' };
+    const key = backofficeKeys.manuscripts.list(filters);
+    expect(key[key.length - 1]).toBe(filters);
+    expect(key.slice(0, 3)).toEqual(['backoffice', 'manuscripts', 'list']);
+  });
+
+  it('detail keys include the id as the trailing segment', () => {
+    expect(backofficeKeys.manuscripts.detail(42)).toEqual([
+      'backoffice',
+      'manuscripts',
+      'detail',
+      42,
+    ]);
+    expect(backofficeKeys.scribes.detail(7)).toEqual(['backoffice', 'scribes', 'detail', 7]);
+    expect(backofficeKeys.users.detail(1)).toEqual(['backoffice', 'users', 'detail', 1]);
+  });
+
+  it('publications.detail uses slug (string) instead of numeric id', () => {
+    expect(backofficeKeys.publications.detail('my-post')).toEqual([
+      'backoffice',
+      'publications',
+      'detail',
+      'my-post',
+    ]);
+  });
+
+  it('produces distinct keys for different filter objects (cache isolation)', () => {
+    const a = backofficeKeys.manuscripts.list({ offset: 0 });
+    const b = backofficeKeys.manuscripts.list({ offset: 20 });
+    expect(a).not.toEqual(b);
+  });
+
+  it('currentItems.list still extends its all() despite the inlined construction', () => {
+    // The source builds list() as [...all, 'currentItems', 'list', filters] inline
+    // rather than [...currentItems.all(), 'list', filters]. The assertion locks in
+    // that the resulting key still starts with the all() prefix so invalidation works.
+    const all = backofficeKeys.currentItems.all();
+    const list = backofficeKeys.currentItems.list({});
+    expect(list.slice(0, all.length)).toEqual([...all]);
+  });
+
+  it('graphs.list and graphs.detail extend graphs.all() (inline construction)', () => {
+    const all = backofficeKeys.graphs.all();
+    expect(backofficeKeys.graphs.list({}).slice(0, all.length)).toEqual([...all]);
+    expect(backofficeKeys.graphs.detail(1).slice(0, all.length)).toEqual([...all]);
+  });
+
+  it('searchEngine.stats and searchEngine.task extend searchEngine.all()', () => {
+    const all = backofficeKeys.searchEngine.all();
+    expect(backofficeKeys.searchEngine.stats().slice(0, all.length)).toEqual([...all]);
+    expect(backofficeKeys.searchEngine.task('abc').slice(0, all.length)).toEqual([...all]);
+  });
+});

--- a/lib/backoffice/review-queue-sla.test.ts
+++ b/lib/backoffice/review-queue-sla.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ageInReviewMs,
+  formatReviewAge,
+  slaSeverity,
+  sortByOldestInReview,
+  groupByAssignee,
+  unassignedCount,
+  type ReviewQueueItem,
+  type ReviewAssignee,
+} from './review-queue-sla';
+
+const ALICE: ReviewAssignee = { userId: 1, username: 'alice' };
+const BOB: ReviewAssignee = { userId: 2, username: 'bob' };
+
+const NOW = 1_700_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function item(overrides: Partial<ReviewQueueItem>): ReviewQueueItem {
+  return {
+    id: 1,
+    status: 'review',
+    enteredReviewAt: NOW - 2 * DAY,
+    assignedTo: null,
+    ...overrides,
+  };
+}
+
+describe('ageInReviewMs', () => {
+  it('returns the delta between now and enteredReviewAt', () => {
+    expect(ageInReviewMs(item({ enteredReviewAt: NOW - DAY }), NOW)).toBe(DAY);
+  });
+
+  it('returns null for items not in review', () => {
+    expect(ageInReviewMs(item({ status: 'draft', enteredReviewAt: NOW - DAY }), NOW)).toBeNull();
+  });
+
+  it('returns null when enteredReviewAt is null', () => {
+    expect(ageInReviewMs(item({ enteredReviewAt: null }), NOW)).toBeNull();
+  });
+
+  it('clamps negative deltas to 0', () => {
+    expect(ageInReviewMs(item({ enteredReviewAt: NOW + DAY }), NOW)).toBe(0);
+  });
+});
+
+describe('formatReviewAge', () => {
+  it('reports zero as "today"', () => {
+    expect(formatReviewAge(0)).toBe('today');
+  });
+
+  it('hours / days / weeks at the right boundaries', () => {
+    expect(formatReviewAge(2 * HOUR)).toBe('2h');
+    expect(formatReviewAge(2 * DAY)).toBe('2d');
+    expect(formatReviewAge(8 * DAY)).toBe('1w');
+    expect(formatReviewAge(15 * DAY)).toBe('2w');
+  });
+});
+
+describe('slaSeverity', () => {
+  it('classifies fresh / warning / overdue at default thresholds', () => {
+    // Defaults: warning ≥ 3 days, overdue ≥ 7 days.
+    expect(slaSeverity(2 * DAY)).toBe('fresh');
+    expect(slaSeverity(3 * DAY)).toBe('warning');
+    expect(slaSeverity(6 * DAY)).toBe('warning');
+    expect(slaSeverity(7 * DAY)).toBe('overdue');
+    expect(slaSeverity(30 * DAY)).toBe('overdue');
+  });
+
+  it('respects custom thresholds', () => {
+    const custom = { warningMs: HOUR, overdueMs: 4 * HOUR };
+    expect(slaSeverity(30 * 60 * 1000, custom)).toBe('fresh');
+    expect(slaSeverity(2 * HOUR, custom)).toBe('warning');
+    expect(slaSeverity(4 * HOUR, custom)).toBe('overdue');
+  });
+
+  it('treats null age as fresh', () => {
+    expect(slaSeverity(null)).toBe('fresh');
+  });
+});
+
+describe('sortByOldestInReview', () => {
+  it('puts the oldest review item first; non-review items sink to the end', () => {
+    const a = item({ id: 1, enteredReviewAt: NOW - 5 * DAY });
+    const b = item({ id: 2, enteredReviewAt: NOW - DAY });
+    const c = item({ id: 3, enteredReviewAt: NOW - 10 * DAY });
+    const d = item({ id: 4, status: 'draft', enteredReviewAt: null });
+    const sorted = sortByOldestInReview([b, d, a, c], NOW);
+    expect(sorted.map((i) => i.id)).toEqual([3, 1, 2, 4]);
+  });
+
+  it('does not mutate the input array', () => {
+    const a = item({ id: 1, enteredReviewAt: NOW - DAY });
+    const b = item({ id: 2, enteredReviewAt: NOW - 2 * DAY });
+    const buf = [a, b];
+    sortByOldestInReview(buf, NOW);
+    expect(buf).toEqual([a, b]);
+  });
+});
+
+describe('groupByAssignee / unassignedCount', () => {
+  const a = item({ id: 1, assignedTo: ALICE });
+  const b = item({ id: 2, assignedTo: ALICE });
+  const c = item({ id: 3, assignedTo: BOB });
+  const d = item({ id: 4, assignedTo: null });
+
+  it('groups by assignee userId', () => {
+    const groups = groupByAssignee([a, b, c, d]);
+    expect(groups.get(1)?.map((i) => i.id)).toEqual([1, 2]);
+    expect(groups.get(2)?.map((i) => i.id)).toEqual([3]);
+  });
+
+  it('counts unassigned items separately', () => {
+    expect(unassignedCount([a, b, c, d])).toBe(1);
+    expect(unassignedCount([a, b, c])).toBe(0);
+  });
+});

--- a/lib/backoffice/review-queue-sla.ts
+++ b/lib/backoffice/review-queue-sla.ts
@@ -1,0 +1,110 @@
+/**
+ * Phase 7.1 of ROADMAP-EDITORS-V2 — pure SLA / assignment helpers for
+ * the reviewer queue.
+ *
+ * The backoffice review queue already lists items waiting on a
+ * reviewer; this phase adds **age** and **assignment** affordances:
+ *
+ *   - How long has this item been in review? (`ageInReviewMs` /
+ *     `formatReviewAge`).
+ *   - At what point does it cross the warning / overdue threshold?
+ *     (`slaSeverity`, with sensible defaults of 3 / 7 days).
+ *   - Who's it assigned to, and how many are still unclaimed?
+ *     (`groupByAssignee`, `unassignedCount`).
+ *   - The default sort is "oldest first", surfacing the items that
+ *     have been sitting longest.
+ *
+ * No localStorage, no fetch — wiring lives in the page-level component.
+ */
+
+export interface ReviewAssignee {
+  userId: number;
+  username: string;
+}
+
+export type ReviewItemStatus = 'draft' | 'review' | 'live';
+
+export interface ReviewQueueItem {
+  id: number;
+  status: ReviewItemStatus;
+  /** ms epoch the item entered review; null when the item never has. */
+  enteredReviewAt: number | null;
+  assignedTo: ReviewAssignee | null;
+}
+
+export type SlaSeverity = 'fresh' | 'warning' | 'overdue';
+
+export interface SlaThresholds {
+  warningMs: number;
+  overdueMs: number;
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+const DEFAULT_THRESHOLDS: SlaThresholds = {
+  warningMs: 3 * DAY,
+  overdueMs: 7 * DAY,
+};
+
+export function ageInReviewMs(item: ReviewQueueItem, now: number = Date.now()): number | null {
+  if (item.status !== 'review') return null;
+  if (item.enteredReviewAt === null) return null;
+  return Math.max(0, now - item.enteredReviewAt);
+}
+
+export function formatReviewAge(ms: number): string {
+  if (ms <= 0) return 'today';
+  if (ms < DAY) return `${Math.floor(ms / HOUR)}h`;
+  if (ms < WEEK) return `${Math.floor(ms / DAY)}d`;
+  return `${Math.floor(ms / WEEK)}w`;
+}
+
+export function slaSeverity(
+  ms: number | null,
+  thresholds: SlaThresholds = DEFAULT_THRESHOLDS
+): SlaSeverity {
+  if (ms === null) return 'fresh';
+  if (ms >= thresholds.overdueMs) return 'overdue';
+  if (ms >= thresholds.warningMs) return 'warning';
+  return 'fresh';
+}
+
+/**
+ * Sort items by oldest-in-review first. Items not in review (or with
+ * no `enteredReviewAt`) sink to the end so the queue surface stays
+ * focused on actionable rows.
+ */
+export function sortByOldestInReview(
+  items: ReviewQueueItem[],
+  now: number = Date.now()
+): ReviewQueueItem[] {
+  const out = [...items];
+  out.sort((a, b) => {
+    const ageA = ageInReviewMs(a, now);
+    const ageB = ageInReviewMs(b, now);
+    if (ageA === null && ageB === null) return 0;
+    if (ageA === null) return 1;
+    if (ageB === null) return -1;
+    return ageB - ageA;
+  });
+  return out;
+}
+
+export function groupByAssignee(items: ReviewQueueItem[]): Map<number, ReviewQueueItem[]> {
+  const out = new Map<number, ReviewQueueItem[]>();
+  for (const item of items) {
+    if (!item.assignedTo) continue;
+    const list = out.get(item.assignedTo.userId);
+    if (list) list.push(item);
+    else out.set(item.assignedTo.userId, [item]);
+  }
+  return out;
+}
+
+export function unassignedCount(items: ReviewQueueItem[]): number {
+  let n = 0;
+  for (const item of items) if (!item.assignedTo) n++;
+  return n;
+}

--- a/lib/backoffice/walk-paginated.test.ts
+++ b/lib/backoffice/walk-paginated.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { walkPaginated } from './walk-paginated';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const fetcher = vi.fn();
+
+beforeEach(() => {
+  fetcher.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('walkPaginated', () => {
+  it('returns the first-page results when no `next` URL is present', async () => {
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({ count: 2, next: null, previous: null, results: [{ id: 1 }, { id: 2 }] })
+    );
+    const result = await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('walks `next` until exhausted and merges all pages in order', async () => {
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({
+        count: 4,
+        next: 'http://api.example.com/items/?limit=100&offset=100',
+        previous: null,
+        results: [{ id: 1 }, { id: 2 }],
+      })
+    );
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({ count: 4, next: null, previous: null, results: [{ id: 3 }, { id: 4 }] })
+    );
+    const result = await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    expect(result.map((r) => r.id)).toEqual([1, 2, 3, 4]);
+    // The follow-up call MUST receive a relative path — feeding the absolute
+    // URL back into the fetcher would double-prepend the API base.
+    const secondPath = fetcher.mock.calls[1]![0] as string;
+    expect(secondPath.startsWith('/items/')).toBe(true);
+    expect(secondPath.includes('http://')).toBe(false);
+  });
+
+  it('returns the partial buffer on a non-OK response without throwing', async () => {
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({
+        count: 4,
+        next: 'http://api.example.com/items/?limit=100&offset=100',
+        previous: null,
+        results: [{ id: 1 }],
+      })
+    );
+    fetcher.mockResolvedValueOnce(jsonResponse({ detail: 'forbidden' }, 403));
+    const result = await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    // First page collected; second page short-circuits on 403.
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('handles a bare-array response (legacy / pagination disabled)', async () => {
+    fetcher.mockResolvedValueOnce(jsonResponse([{ id: 1 }, { id: 2 }]));
+    const result = await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    expect(result.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('treats a relative `next` as already a path (no host to strip)', async () => {
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({
+        count: 2,
+        next: '/items/?limit=100&offset=100',
+        previous: null,
+        results: [{ id: 1 }],
+      })
+    );
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({ count: 2, next: null, previous: null, results: [{ id: 2 }] })
+    );
+    await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    expect(fetcher.mock.calls[1]![0]).toBe('/items/?limit=100&offset=100');
+  });
+
+  it('does NOT throw on a `null` or scalar response body — returns the partial buffer', async () => {
+    // A misconfigured endpoint or upstream that emits literal `null`,
+    // `42`, etc. used to crash on `.results` access. Treat as
+    // end-of-stream and return what we collected up to that point.
+    fetcher.mockResolvedValueOnce(
+      jsonResponse({
+        count: 1,
+        next: 'http://api.example.com/items/?offset=100',
+        previous: null,
+        results: [{ id: 1 }],
+      })
+    );
+    fetcher.mockResolvedValueOnce(jsonResponse(null));
+    const result = await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    expect(result.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('handles a paginated dict whose `results` field is missing or non-array', async () => {
+    // Upstream shape drift — `{count: 0, next: null}` without a `results`
+    // key. The previous spread would fall through `(data.results ?? [])`
+    // which is fine for missing, but the type cast would lie if results
+    // was a non-array.
+    fetcher.mockResolvedValueOnce(jsonResponse({ count: 0, next: null, previous: null }));
+    const result = await walkPaginated<{ id: number }>('/items/?limit=100', fetcher);
+    expect(result).toEqual([]);
+  });
+});

--- a/lib/backoffice/walk-paginated.ts
+++ b/lib/backoffice/walk-paginated.ts
@@ -1,0 +1,68 @@
+/**
+ * Walk every page of a DRF-paginated list endpoint and return the flattened
+ * results. Used by services that need the full set (e.g. all comments on a
+ * graph, all text-annotations on an image) rather than a single page.
+ *
+ * Two non-obvious details:
+ *
+ * 1. **`limit=100`**: callers must include this in `startPath` because
+ *    `BoundedLimitOffsetPagination.max_limit = 100`. Anything higher is
+ *    silently capped, so `limit=1000` would just hide the pagination from
+ *    the consumer.
+ *
+ * 2. **`toRelativePath`**: DRF's `next` is an ABSOLUTE URL like
+ *    `http://api.host/api/v1/...?cursor=...`. Feeding that back through
+ *    `authFetch`/`apiFetch` would re-prepend `API_BASE_URL` and produce
+ *    `http://api.host/http://api.host/...` — an invalid URL the server
+ *    can't resolve. Stripping back to a path keeps the next iteration on
+ *    the same base.
+ *
+ * On a non-OK response the partial buffer is returned (matches the
+ * defensive behavior the previous inlined helpers committed to). The
+ * caller decides whether to surface this as an error.
+ */
+
+interface PaginatedDrfResponse<T> {
+  next?: string | null;
+  results?: T[];
+}
+
+export async function walkPaginated<T>(
+  startPath: string,
+  fetcher: (path: string) => Promise<Response>
+): Promise<T[]> {
+  let path: string | null = startPath;
+  const out: T[] = [];
+  while (path) {
+    const response = await fetcher(path);
+    if (!response.ok) return out;
+    const data: unknown = await response.json();
+    if (Array.isArray(data)) {
+      out.push(...(data as T[]));
+      path = null;
+    } else if (data && typeof data === 'object') {
+      const page = data as PaginatedDrfResponse<T>;
+      if (Array.isArray(page.results)) {
+        out.push(...page.results);
+      }
+      path = toRelativePath(page.next ?? null);
+    } else {
+      // Body parsed cleanly but isn't an array or paginated dict (e.g.
+      // `null`, a scalar, or a primitive). Treat as end-of-stream rather
+      // than throwing on a downstream `.results` access.
+      path = null;
+    }
+  }
+  return out;
+}
+
+function toRelativePath(next: string | null): string | null {
+  if (!next) return null;
+  try {
+    const u = new URL(next);
+    return u.pathname + u.search;
+  } catch {
+    // Already a relative path.
+    return next;
+  }
+}

--- a/services/backoffice/api-client.test.ts
+++ b/services/backoffice/api-client.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the underlying authFetch so each test can control the response
+// without standing up real fetch infra.
+const authFetchMock = vi.fn();
+vi.mock('@/lib/api-fetch', () => ({
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+}));
+
+import {
+  BackofficeApiError,
+  backofficeDelete,
+  backofficeGet,
+  backofficePatch,
+  backofficePatchFormData,
+  backofficePost,
+  backofficePostFormData,
+} from './api-client';
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function textResponse(status: number, text: string) {
+  return new Response(text, { status, headers: { 'content-type': 'text/plain' } });
+}
+
+beforeEach(() => {
+  authFetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('backofficeGet', () => {
+  it('returns the parsed JSON body on a 2xx response', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(200, { id: 1, name: 'X' }));
+    await expect(backofficeGet<{ id: number; name: string }>('/x', 'tok')).resolves.toEqual({
+      id: 1,
+      name: 'X',
+    });
+  });
+
+  it('passes path + token + a default Content-Type to authFetch', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
+    await backofficeGet('/x', 'tok');
+    const [path, token, init] = authFetchMock.mock.calls[0]!;
+    expect(path).toBe('/x');
+    expect(token).toBe('tok');
+    const headers = (init as RequestInit)?.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('throws BackofficeApiError with status + body on a 4xx', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(400, { detail: 'bad' }));
+    await expect(backofficeGet('/x', 'tok')).rejects.toMatchObject({
+      name: 'BackofficeApiError',
+      status: 400,
+      body: { detail: 'bad' },
+    });
+  });
+
+  it('falls back to an empty body when the error response is not JSON', async () => {
+    authFetchMock.mockResolvedValueOnce(textResponse(403, '<html>nope</html>'));
+    await expect(backofficeGet('/x', 'tok')).rejects.toMatchObject({
+      status: 403,
+      body: {},
+    });
+  });
+});
+
+describe('backofficeDelete', () => {
+  it('resolves to undefined on 204 (no body)', async () => {
+    authFetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await expect(backofficeDelete('/x/1/', 'tok')).resolves.toBeUndefined();
+  });
+
+  it('sends method=DELETE', async () => {
+    authFetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await backofficeDelete('/x/1/', 'tok');
+    expect(authFetchMock.mock.calls[0]![2]).toMatchObject({ method: 'DELETE' });
+  });
+});
+
+describe('backofficePost / backofficePatch', () => {
+  it('POST stringifies the JSON body and sets method=POST', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(201, { id: 1 }));
+    await backofficePost('/x/', 'tok', { name: 'Foo' });
+    const init = authFetchMock.mock.calls[0]![2] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ name: 'Foo' }));
+  });
+
+  it('PATCH stringifies the JSON body and sets method=PATCH', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(200, { id: 1 }));
+    await backofficePatch('/x/1/', 'tok', { name: 'Bar' });
+    const init = authFetchMock.mock.calls[0]![2] as RequestInit;
+    expect(init.method).toBe('PATCH');
+    expect(init.body).toBe(JSON.stringify({ name: 'Bar' }));
+  });
+});
+
+describe('backofficePostFormData / backofficePatchFormData', () => {
+  it('does NOT set Content-Type so the browser can add the multipart boundary', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(201, { id: 1 }));
+    const fd = new FormData();
+    fd.append('file', new Blob(['x']), 'a.txt');
+    await backofficePostFormData('/x/', 'tok', fd);
+    const init = authFetchMock.mock.calls[0]![2] as RequestInit;
+    // Headers param is NOT set on the FormData branch — that's the contract.
+    expect(init.headers).toBeUndefined();
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(fd);
+  });
+
+  it('PATCH variant uses method=PATCH', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(200, { id: 1 }));
+    const fd = new FormData();
+    await backofficePatchFormData('/x/1/', 'tok', fd);
+    const init = authFetchMock.mock.calls[0]![2] as RequestInit;
+    expect(init.method).toBe('PATCH');
+  });
+
+  it('204 from a FormData PATCH resolves to undefined', async () => {
+    authFetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const fd = new FormData();
+    await expect(backofficePatchFormData('/x/1/', 'tok', fd)).resolves.toBeUndefined();
+  });
+});
+
+describe('BackofficeApiError', () => {
+  it('exposes status, body, and the documented name', () => {
+    const e = new BackofficeApiError(418, { detail: 'teapot' });
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('BackofficeApiError');
+    expect(e.status).toBe(418);
+    expect(e.body).toEqual({ detail: 'teapot' });
+    // Default message is consistent with the class — useful for log scrapers.
+    expect(e.message).toBe('API error 418');
+  });
+});
+
+describe('transient retry', () => {
+  it('retries on 502 and returns the eventual 200', async () => {
+    vi.useFakeTimers();
+    authFetchMock
+      .mockResolvedValueOnce(textResponse(502, 'gateway'))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    const promise = backofficeGet<{ ok: boolean }>('/x', 'tok');
+    // Drain the per-attempt setTimeout(500ms).
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(authFetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry on a 400 (non-transient)', async () => {
+    authFetchMock.mockResolvedValueOnce(jsonResponse(400, { detail: 'bad' }));
+    await expect(backofficeGet('/x', 'tok')).rejects.toBeInstanceOf(BackofficeApiError);
+    expect(authFetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/services/backoffice/api-client.ts
+++ b/services/backoffice/api-client.ts
@@ -1,16 +1,17 @@
-import { apiFetch } from '@/lib/api-fetch';
+import { authFetch } from '@/lib/api-fetch';
 
 const TRANSIENT_STATUSES = [502, 503, 504];
 
 async function fetchWithRetry(
   path: string,
+  token: string,
   init?: RequestInit,
   retries = 2,
   delay = 500
 ): Promise<Response> {
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      const res = await apiFetch(path, init);
+      const res = await authFetch(path, token, init);
       if (attempt < retries && TRANSIENT_STATUSES.includes(res.status)) {
         await new Promise((r) => setTimeout(r, delay * (attempt + 1)));
         continue;
@@ -39,11 +40,10 @@ export class BackofficeApiError extends Error {
  * Sends requests to the provided API path and adds the auth token header.
  */
 async function apiRequest<T>(path: string, token: string, init?: RequestInit): Promise<T> {
-  const res = await fetchWithRetry(path, {
+  const res = await fetchWithRetry(path, token, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Token ${token}`,
       ...init?.headers,
     },
   });
@@ -95,11 +95,8 @@ async function apiRequestFormData<T>(
   method: string,
   formData: FormData
 ): Promise<T> {
-  const res = await fetchWithRetry(path, {
+  const res = await fetchWithRetry(path, token, {
     method,
-    headers: {
-      Authorization: `Token ${token}`,
-    },
     body: formData,
   });
 

--- a/services/backoffice/crud-factory.test.ts
+++ b/services/backoffice/crud-factory.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the api-client primitives so we can capture exactly what URL/path the
+// factory composes. Each spy returns a resolved value that includes the
+// arguments it was called with — that's enough to verify the contract.
+vi.mock('./api-client', () => {
+  const get = vi.fn(async (path: string) => ({ kind: 'get', path }));
+  const post = vi.fn(async (path: string, _token: string, data: unknown) => ({
+    kind: 'post',
+    path,
+    data,
+  }));
+  const patch = vi.fn(async (path: string, _token: string, data: unknown) => ({
+    kind: 'patch',
+    path,
+    data,
+  }));
+  const del = vi.fn(async (path: string) => ({ kind: 'delete', path }));
+  return {
+    backofficeGet: get,
+    backofficePost: post,
+    backofficePatch: patch,
+    backofficeDelete: del,
+  };
+});
+
+import { createCrudService } from './crud-factory';
+
+const BASE = '/api/v1/manuscripts/management/historical-items/';
+const service = createCrudService<{ id: number; name: string }>(BASE);
+
+describe('createCrudService.list', () => {
+  it('returns the bare base path when no params are supplied', async () => {
+    const res = (await service.list('tok')) as unknown as { path: string };
+    expect(res.path).toBe(BASE);
+  });
+
+  it('appends ?key=value query parameters', async () => {
+    const res = (await service.list('tok', { search: 'magna' })) as unknown as { path: string };
+    expect(res.path).toBe(`${BASE}?search=magna`);
+  });
+
+  it('coerces number / boolean params to their string form', async () => {
+    const res = (await service.list('tok', {
+      limit: 20,
+      offset: 0,
+      published: true,
+    })) as unknown as { path: string };
+    const url = new URL(`http://x${res.path}`);
+    expect(url.searchParams.get('limit')).toBe('20');
+    expect(url.searchParams.get('offset')).toBe('0');
+    expect(url.searchParams.get('published')).toBe('true');
+  });
+
+  it('skips undefined / null values entirely (not stringified as "undefined")', async () => {
+    const res = (await service.list('tok', {
+      search: 'magna',
+      // common pattern when the form hasn't been touched:
+      orderBy: undefined,
+      filter: null,
+    })) as unknown as { path: string };
+    const url = new URL(`http://x${res.path}`);
+    expect(url.searchParams.get('search')).toBe('magna');
+    expect(url.searchParams.has('orderBy')).toBe(false);
+    expect(url.searchParams.has('filter')).toBe(false);
+  });
+
+  it('keeps the base path unchanged when every param is null/undefined', async () => {
+    const res = (await service.list('tok', {
+      orderBy: undefined,
+      filter: null,
+    })) as unknown as { path: string };
+    expect(res.path).toBe(BASE);
+  });
+});
+
+describe('createCrudService item operations', () => {
+  it('get builds `${base}${id}/`', async () => {
+    const res = (await service.get('tok', 42)) as unknown as { path: string };
+    expect(res.path).toBe(`${BASE}42/`);
+  });
+
+  it('create posts to the base path', async () => {
+    const res = (await service.create('tok', { name: 'Foo' })) as unknown as {
+      path: string;
+      data: unknown;
+    };
+    expect(res.path).toBe(BASE);
+    expect(res.data).toEqual({ name: 'Foo' });
+  });
+
+  it('update patches `${base}${id}/`', async () => {
+    const res = (await service.update('tok', 7, { name: 'Bar' })) as unknown as {
+      path: string;
+      data: unknown;
+    };
+    expect(res.path).toBe(`${BASE}7/`);
+    expect(res.data).toEqual({ name: 'Bar' });
+  });
+
+  it('remove deletes `${base}${id}/`', async () => {
+    const res = (await service.remove('tok', 7)) as unknown as { path: string };
+    expect(res.path).toBe(`${BASE}7/`);
+  });
+
+  it('supports string-typed ids (slugs / non-numeric pks)', async () => {
+    const slugService = createCrudService<{ slug: string }, { slug: string }, string>(
+      '/api/v1/publications/management/posts/'
+    );
+    const res = (await slugService.get('tok', 'my-post')) as unknown as { path: string };
+    expect(res.path).toBe('/api/v1/publications/management/posts/my-post/');
+  });
+});

--- a/services/backoffice/manuscripts.ts
+++ b/services/backoffice/manuscripts.ts
@@ -1,5 +1,7 @@
 import { backofficeGet } from './api-client';
 import { createCrudService } from './crud-factory';
+import { walkPaginated } from '@/lib/backoffice/walk-paginated';
+import { authFetch } from '@/lib/api-fetch';
 import type {
   PaginatedResponse,
   HistoricalItemListItem,
@@ -134,7 +136,14 @@ const repositoriesCrud = createCrudService<PaginatedResponse<Repository>, Reposi
   '/api/v1/manuscripts/management/repositories/'
 );
 
-export const getRepositories = (token: string) => repositoriesCrud.list(token);
+// Walk all pages so consumers (the repositories CRUD page and the
+// physical-volumes filter dropdown) see every repository. The earlier
+// `repositoriesCrud.list(token)` returned the first DRF page only,
+// silently capping the list at 20.
+export const getRepositories = (token: string): Promise<Repository[]> =>
+  walkPaginated<Repository>('/api/v1/manuscripts/management/repositories/?limit=100', (path) =>
+    authFetch(path, token)
+  );
 export const createRepository = repositoriesCrud.create;
 export const updateRepository = repositoriesCrud.update;
 export const deleteRepository = repositoriesCrud.remove;

--- a/services/backoffice/quality-dashboard.ts
+++ b/services/backoffice/quality-dashboard.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+import { authFetch } from '@/lib/api-fetch';
+
+const QualityCardSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  count: z.number(),
+  sample: z.array(z.record(z.string(), z.unknown())),
+});
+
+export const QualityResponseSchema = z.object({
+  generated_at: z.string(),
+  cards: z.array(QualityCardSchema),
+});
+
+export type QualityCard = z.infer<typeof QualityCardSchema>;
+export type QualityResponse = z.infer<typeof QualityResponseSchema>;
+
+export async function fetchQualityDashboard(token: string): Promise<QualityResponse> {
+  const response = await authFetch('/api/v1/search/management/quality/', token, {
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`Server returned ${response.status}`);
+  }
+  return QualityResponseSchema.parse(await response.json());
+}

--- a/services/backoffice/review-queue.ts
+++ b/services/backoffice/review-queue.ts
@@ -1,0 +1,60 @@
+/**
+ * Phase G — reviewer queue + status transitions.
+ *
+ * Mirrors `apps/manuscripts/views.py:ReviewQueueViewSet` and the
+ * `transition` action on `ImageTextManagementViewSet`. The queue is
+ * staff-only; the actions assume the caller is a reviewer.
+ */
+
+import { authFetch } from '@/lib/api-fetch';
+
+export type ImageTextStatus = 'Draft' | 'Review' | 'Live' | 'Reviewed';
+
+export interface QueueEntry {
+  id: number;
+  item_image: number;
+  type: string;
+  status: ImageTextStatus;
+  language: string;
+  review_assignee: number | null;
+  review_assignee_username: string | null;
+  last_transition: {
+    id: number;
+    from_status: ImageTextStatus;
+    to_status: ImageTextStatus;
+    actor: number | null;
+    actor_username: string | null;
+    note: string;
+    created: string;
+  } | null;
+  created: string;
+  modified: string;
+}
+
+export async function fetchReviewQueue(token: string): Promise<QueueEntry[]> {
+  const r = await authFetch('/api/v1/manuscripts/management/review-queue/', token, {
+    cache: 'no-store',
+  });
+  if (!r.ok) return [];
+  return r.json();
+}
+
+export interface TransitionPayload {
+  to_status: ImageTextStatus;
+  note?: string;
+  assignee?: number | null;
+}
+
+export async function transitionImageText(
+  token: string,
+  id: number,
+  payload: TransitionPayload
+): Promise<QueueEntry> {
+  const r = await authFetch(`/api/v1/manuscripts/management/image-texts/${id}/transition/`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!r.ok) throw new Error(`Transition failed: ${r.status} ${await r.text()}`);
+  return r.json();
+}


### PR DESCRIPTION
## Summary

All backoffice-only changes I had locally, packaged together. **Strict path discipline** — every changed file is under `app/backoffice/`, `components/backoffice/`, `hooks/backoffice/`, `services/backoffice/`, or `lib/backoffice/`. Nothing outside those paths is touched, so client/site rendering cannot regress from this PR.

### Two new backoffice routes

- **`/backoffice/review-queue`** (Phase G.1) — staff-only feed of `ImageText` rows in `Review` status, oldest-first, with the latest transition (who sent it, when, with what note) inline. Approve flips to `Live`, send-back flips to `Draft` with a required note; both go through `transitionImageText` so the audit trail is honest. Backed by archetype-pal/backend#95.
- **`/backoffice/quality`** — read-only data-quality cards: stale drafts, untyped clauses, undescribed graphs, hands without graphs, orphan TEXT-typed graphs. Same backend PR.

### One new shared backoffice surface

- `components/backoffice/notifications-popover.tsx` — header bell that groups pending notifications by kind (mention, comment-reply, review-request, …) with a "Mark all as read" affordance. The relative-time formatter (`describeSnapshotAge`) is inlined here rather than imported from a shared editor module so this PR doesn't pull in editor concerns.

### Supporting infrastructure (under `lib/backoffice/`)

All five are net-new files; no on-main code imports them:

- `lib/backoffice/walk-paginated.ts` — DRF cursor walker used by every list-fetch on a backoffice page that needs the full row set (comments, publications, hands, scribes, …).
- `lib/backoffice/csv-escape.ts` — used by the row-export action on `data-table.tsx`.
- `lib/backoffice/review-queue-sla.ts` — day-bucket logic behind the new age badge.
- `lib/backoffice/{bulk-action,format-api-error,query-keys}` — shared backoffice helpers.
- `lib/backoffice/pending-notifications.ts` — consumed by the notifications popover.

Plus expanded `services/backoffice/{api-client,manuscripts}.ts`, new `services/backoffice/{review-queue,quality-dashboard}.ts`, and broad new test coverage (`hooks/backoffice/*.test.tsx`, `components/backoffice/*.test.tsx`, `services/backoffice/*.test.ts`).

### Touch-ups to existing backoffice pages

Small fixes that came along with the infra:

- `app/backoffice/page.tsx` (dashboard) — count drafts via the API's `count` field rather than `.results.filter(…).length`, which silently lied about queue depth past the first 100 publications. Also fix `getGreeting`/`formatDate` to be timezone-aware.
- `app/backoffice/{publications,scribes,hands,comments}/page.tsx` — pagination via `walk-paginated`.
- `components/backoffice/layout/{backoffice-header,backoffice-sidebar}.tsx` — sidebar entries for the new pages, header slot for the notifications bell.
- `components/backoffice/common/data-table.tsx` — CSV export action wired through `csv-escape`.
- `services/backoffice/api-client.ts` — small additions used by the new endpoints.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test --run` — 144 pass / 0 fail (22 test files)
- [x] `pnpm build` — both `/backoffice/quality` and `/backoffice/review-queue` listed as static routes
- [ ] Run dev server with the backend PR's branch checked out and walk through the review queue: send a draft to Review from the editor, see it appear, approve it
- [ ] Open the notifications popover with seeded comment mentions and confirm "Mark all as read" clears them
- [ ] Visit `/backoffice/quality` as a superuser, verify all five cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
