### PR TITLE
refactor(backoffice): admin API routes use authFetch + harden config helpers

### DIFF
--- a/app/api/model-labels/route.ts
+++ b/app/api/model-labels/route.ts
@@ -1,14 +1,12 @@
 import { revalidatePath } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
-import { env } from '@/lib/env';
+import { authFetch } from '@/lib/api-fetch';
 import { readModelLabels, writeModelLabels } from '@/lib/model-labels-server';
 import { normalizeModelLabels, type ModelLabelsConfig } from '@/lib/model-labels';
 
 async function verifySuperuser(token: string): Promise<boolean> {
   try {
-    const res = await fetch(`${env.apiUrl}/api/v1/auth/profile`, {
-      headers: { Authorization: `Token ${token}` },
-    });
+    const res = await authFetch('/api/v1/auth/profile', token);
     if (!res.ok) return false;
     const user = await res.json();
     return user.is_superuser === true;

--- a/app/api/site-features/route.ts
+++ b/app/api/site-features/route.ts
@@ -1,14 +1,12 @@
 import { revalidatePath } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
+import { authFetch } from '@/lib/api-fetch';
 import { readSiteFeatures, writeSiteFeatures } from '@/lib/site-features-server';
 import type { SiteFeaturesConfig } from '@/lib/site-features';
-import { env } from '@/lib/env';
 
 async function verifyStaff(token: string): Promise<boolean> {
   try {
-    const res = await fetch(`${env.apiUrl}/api/v1/auth/profile`, {
-      headers: { Authorization: `Token ${token}` },
-    });
+    const res = await authFetch('/api/v1/auth/profile', token);
     if (!res.ok) return false;
     const user = await res.json();
     return user.is_staff === true;
@@ -43,7 +41,9 @@ export async function PUT(request: NextRequest) {
   if (!body || typeof body !== 'object' || !('sections' in body) || !('searchCategories' in body)) {
     return NextResponse.json({ error: 'Invalid config shape' }, { status: 400 });
   }
-  await writeSiteFeatures(body as SiteFeaturesConfig);
+  const normalized = await writeSiteFeatures(body as SiteFeaturesConfig);
   revalidatePath('/', 'layout');
-  return NextResponse.json(body);
+  // Return the normalized config (with sectionOrder canonicalized) so the
+  // client's cache reflects what's actually on disk.
+  return NextResponse.json(normalized);
 }

--- a/contexts/model-labels-context.test.tsx
+++ b/contexts/model-labels-context.test.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import { render, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_MODEL_LABELS,
+  getDefaultModelLabelsConfig,
+  type ModelLabelsConfig,
+} from '@/lib/model-labels';
+import { ModelLabelsProvider, useModelLabels } from './model-labels-context';
+
+function withProvider(initialConfig?: ModelLabelsConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ModelLabelsProvider initialConfig={initialConfig}>{children}</ModelLabelsProvider>;
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify(getDefaultModelLabelsConfig()), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('useModelLabels (without provider)', () => {
+  it('throws an explicit error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useModelLabels())).toThrow(
+      /useModelLabels must be used within a ModelLabelsProvider/
+    );
+    spy.mockRestore();
+  });
+});
+
+describe('ModelLabelsProvider with initialConfig', () => {
+  it('uses the supplied config and skips the fetch', () => {
+    const cfg = getDefaultModelLabelsConfig();
+    cfg.labels.appManuscripts = 'Charters';
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider(cfg) });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.config).toBe(cfg);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('getLabel returns overridden values', () => {
+    const cfg = getDefaultModelLabelsConfig();
+    cfg.labels.appManuscripts = 'Charters';
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider(cfg) });
+    expect(result.current.getLabel('appManuscripts')).toBe('Charters');
+  });
+
+  it('getLabel falls back to the default when the key is missing in config.labels', () => {
+    const cfg = getDefaultModelLabelsConfig();
+    // @ts-expect-error — testing runtime fallback when a key disappears
+    delete cfg.labels.position;
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider(cfg) });
+    expect(result.current.getLabel('position')).toBe(DEFAULT_MODEL_LABELS.position);
+  });
+
+  it('getPluralLabel pluralizes the resolved label', () => {
+    const cfg = getDefaultModelLabelsConfig();
+    cfg.labels.appManuscripts = 'Charter';
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider(cfg) });
+    expect(result.current.getPluralLabel('appManuscripts')).toBe('Charters');
+  });
+
+  it('getPluralLabel handles ies / es rules transitively', () => {
+    const cfg = getDefaultModelLabelsConfig();
+    cfg.labels.historicalItem = 'City';
+    cfg.labels.catalogueNumber = 'Box';
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider(cfg) });
+    expect(result.current.getPluralLabel('historicalItem')).toBe('Cities');
+    expect(result.current.getPluralLabel('catalogueNumber')).toBe('Boxes');
+  });
+});
+
+describe('ModelLabelsProvider without initialConfig (fetch path)', () => {
+  it('starts loading=true, then fetches and resolves to the response', async () => {
+    const fetched = getDefaultModelLabelsConfig();
+    fetched.labels.appManuscripts = 'Charters';
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(fetched), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    ) as typeof fetch;
+
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider() });
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.getLabel('appManuscripts')).toBe('Charters');
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/model-labels');
+  });
+
+  it('falls back to defaults when fetch errors', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as typeof fetch;
+
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider() });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.config).toEqual(getDefaultModelLabelsConfig());
+  });
+
+  it('falls back to defaults on a non-OK response', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as typeof fetch;
+
+    const { result } = renderHook(() => useModelLabels(), { wrapper: withProvider() });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.config).toEqual(getDefaultModelLabelsConfig());
+  });
+});
+
+describe('ModelLabelsProvider sync with replaced initialConfig prop', () => {
+  it('adopts a new initialConfig when the prop reference changes (e.g. router.refresh)', () => {
+    const cfgA = getDefaultModelLabelsConfig();
+    cfgA.labels.appManuscripts = 'A';
+    const cfgB = getDefaultModelLabelsConfig();
+    cfgB.labels.appManuscripts = 'B';
+
+    const probeRef = React.createRef<{ value: ReturnType<typeof useModelLabels> | null }>();
+    const Probe = React.forwardRef<{ value: ReturnType<typeof useModelLabels> | null }>(
+      function Probe(_props, ref) {
+        const value = useModelLabels();
+        React.useImperativeHandle(ref, () => ({ value }), [value]);
+        return null;
+      }
+    );
+
+    function Holder({ cfg }: { cfg: ModelLabelsConfig }) {
+      return (
+        <ModelLabelsProvider initialConfig={cfg}>
+          <Probe ref={probeRef} />
+        </ModelLabelsProvider>
+      );
+    }
+
+    const { rerender } = render(<Holder cfg={cfgA} />);
+    expect(probeRef.current?.value?.getLabel('appManuscripts')).toBe('A');
+
+    rerender(<Holder cfg={cfgB} />);
+    expect(probeRef.current?.value?.getLabel('appManuscripts')).toBe('B');
+  });
+});

--- a/contexts/site-features-context.test.tsx
+++ b/contexts/site-features-context.test.tsx
@@ -1,0 +1,177 @@
+import * as React from 'react';
+import { render, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getDefaultConfig, type SiteFeaturesConfig } from '@/lib/site-features';
+import { SiteFeaturesProvider, useSiteFeatures } from './site-features-context';
+
+function withProvider(initialConfig?: SiteFeaturesConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <SiteFeaturesProvider initialConfig={initialConfig}>{children}</SiteFeaturesProvider>;
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  // Default: any unmocked fetch returns the canonical defaults so tests that
+  // exercise the fetch fallback path don't hang.
+  globalThis.fetch = vi.fn(
+    async () =>
+      new Response(JSON.stringify(getDefaultConfig()), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('useSiteFeatures (without provider)', () => {
+  it('throws an explicit error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useSiteFeatures())).toThrow(
+      /useSiteFeatures must be used within a SiteFeaturesProvider/
+    );
+    spy.mockRestore();
+  });
+});
+
+describe('SiteFeaturesProvider with initialConfig', () => {
+  it('uses the supplied config and skips the fetch', async () => {
+    const cfg = getDefaultConfig();
+    cfg.sections.lightbox = false;
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider(cfg) });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.config).toBe(cfg);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('isSectionEnabled returns true unless explicitly disabled', () => {
+    const cfg = getDefaultConfig();
+    cfg.sections.lightbox = false;
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider(cfg) });
+    expect(result.current.isSectionEnabled('lightbox')).toBe(false);
+    expect(result.current.isSectionEnabled('search')).toBe(true);
+  });
+
+  it('isSectionEnabled treats missing keys as enabled (only `false` disables)', () => {
+    const cfg = getDefaultConfig();
+    // @ts-expect-error — testing runtime behavior with a synthetic missing key
+    delete cfg.sections.about;
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider(cfg) });
+    expect(result.current.isSectionEnabled('about')).toBe(true);
+  });
+
+  it('getCategoryConfig returns the per-type config when present', () => {
+    const cfg = getDefaultConfig();
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider(cfg) });
+    expect(result.current.getCategoryConfig('manuscripts')).toBe(cfg.searchCategories.manuscripts);
+  });
+
+  it('getCategoryConfig falls back to a permissive default when the type is missing', () => {
+    const cfg = getDefaultConfig();
+    // @ts-expect-error — testing runtime behavior
+    delete cfg.searchCategories.manuscripts;
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider(cfg) });
+    expect(result.current.getCategoryConfig('manuscripts')).toEqual({
+      enabled: true,
+      visibleColumns: [],
+      visibleFacets: [],
+    });
+  });
+
+  it('enabledCategories filters to types whose config.enabled is true', () => {
+    const cfg = getDefaultConfig();
+    cfg.searchCategories.images.enabled = false;
+    cfg.searchCategories.graphs.enabled = false;
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider(cfg) });
+    expect(result.current.enabledCategories).not.toContain('images');
+    expect(result.current.enabledCategories).not.toContain('graphs');
+    expect(result.current.enabledCategories).toContain('manuscripts');
+  });
+});
+
+describe('SiteFeaturesProvider without initialConfig (fetch path)', () => {
+  it('starts loading=true, then fetches and resolves to the response', async () => {
+    const fetched: SiteFeaturesConfig = getDefaultConfig();
+    fetched.sections.events = false;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify(fetched), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    ) as typeof fetch;
+
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider() });
+    // Initial render: loading true, config = defaults
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.config.sections.events).toBe(false);
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/site-features');
+  });
+
+  it('falls back to defaults when fetch errors', async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('network down');
+    }) as typeof fetch;
+
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider() });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.config).toEqual(getDefaultConfig());
+  });
+
+  it('falls back to defaults on a non-OK response', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as typeof fetch;
+
+    const { result } = renderHook(() => useSiteFeatures(), { wrapper: withProvider() });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.config).toEqual(getDefaultConfig());
+  });
+});
+
+describe('SiteFeaturesProvider sync with replaced initialConfig prop', () => {
+  it('adopts a new initialConfig when the prop reference changes (e.g. router.refresh)', () => {
+    const cfgA = getDefaultConfig();
+    cfgA.sections.lightbox = false;
+
+    const cfgB = getDefaultConfig();
+    cfgB.sections.lightbox = true;
+    cfgB.sections.about = false;
+
+    const probeRef = React.createRef<{ value: ReturnType<typeof useSiteFeatures> | null }>();
+    const Probe = React.forwardRef<{ value: ReturnType<typeof useSiteFeatures> | null }>(
+      function Probe(_props, ref) {
+        const value = useSiteFeatures();
+        React.useImperativeHandle(ref, () => ({ value }), [value]);
+        return null;
+      }
+    );
+
+    function Holder({ cfg }: { cfg: SiteFeaturesConfig }) {
+      return (
+        <SiteFeaturesProvider initialConfig={cfg}>
+          <Probe ref={probeRef} />
+        </SiteFeaturesProvider>
+      );
+    }
+
+    const { rerender } = render(<Holder cfg={cfgA} />);
+    expect(probeRef.current?.value?.config).toBe(cfgA);
+
+    rerender(<Holder cfg={cfgB} />);
+    expect(probeRef.current?.value?.config).toBe(cfgB);
+    expect(probeRef.current?.value?.isSectionEnabled('lightbox')).toBe(true);
+    expect(probeRef.current?.value?.isSectionEnabled('about')).toBe(false);
+  });
+});

--- a/lib/model-labels-server.ts
+++ b/lib/model-labels-server.ts
@@ -12,7 +12,13 @@ export async function readModelLabels(): Promise<ModelLabelsConfig> {
   const defaults = getDefaultModelLabelsConfig();
   try {
     const raw = await readFile(CONFIG_PATH, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<ModelLabelsConfig>;
+    const rawParsed: unknown = JSON.parse(raw);
+    // If the file was hand-edited to `null`, an array, or a primitive, we
+    // would have crashed on `parsed.labels` reading below. Bail out to
+    // defaults so SSR doesn't 500 over a broken config file. Mirrors the
+    // same defense in lib/site-features-server.ts (cycle 131).
+    if (!rawParsed || typeof rawParsed !== 'object' || Array.isArray(rawParsed)) return defaults;
+    const parsed = rawParsed as Partial<ModelLabelsConfig>;
     return {
       labels: normalizeModelLabels(parsed.labels),
     };

--- a/lib/model-labels.test.ts
+++ b/lib/model-labels.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_MODEL_LABELS,
+  getDefaultModelLabelsConfig,
+  normalizeModelLabels,
+  pluralizeLabel,
+  type ModelLabelKey,
+} from './model-labels';
+
+describe('normalizeModelLabels', () => {
+  it('returns the canonical defaults when input is undefined', () => {
+    expect(normalizeModelLabels(undefined)).toEqual(DEFAULT_MODEL_LABELS);
+  });
+
+  it('returns the canonical defaults when input is empty', () => {
+    expect(normalizeModelLabels({})).toEqual(DEFAULT_MODEL_LABELS);
+  });
+
+  it('overrides only the keys explicitly provided', () => {
+    const result = normalizeModelLabels({
+      historicalItem: 'Object',
+      catalogueNumber: 'Cat #',
+    });
+    expect(result.historicalItem).toBe('Object');
+    expect(result.catalogueNumber).toBe('Cat #');
+    // Untouched keys keep defaults
+    expect(result.position).toBe(DEFAULT_MODEL_LABELS.position);
+    expect(result.appManuscripts).toBe(DEFAULT_MODEL_LABELS.appManuscripts);
+  });
+
+  it('trims whitespace around override values', () => {
+    expect(normalizeModelLabels({ historicalItem: '   Object   ' }).historicalItem).toBe('Object');
+  });
+
+  it('falls back to the default for empty / whitespace-only strings', () => {
+    const result = normalizeModelLabels({
+      historicalItem: '',
+      catalogueNumber: '   ',
+    });
+    expect(result.historicalItem).toBe(DEFAULT_MODEL_LABELS.historicalItem);
+    expect(result.catalogueNumber).toBe(DEFAULT_MODEL_LABELS.catalogueNumber);
+  });
+
+  it('falls back to the default for non-string values (numbers, null, objects)', () => {
+    const result = normalizeModelLabels({
+      historicalItem: 42 as unknown as string,
+      catalogueNumber: null as unknown as string,
+      position: { foo: 'bar' } as unknown as string,
+    });
+    expect(result.historicalItem).toBe(DEFAULT_MODEL_LABELS.historicalItem);
+    expect(result.catalogueNumber).toBe(DEFAULT_MODEL_LABELS.catalogueNumber);
+    expect(result.position).toBe(DEFAULT_MODEL_LABELS.position);
+  });
+
+  it('does not include keys not in DEFAULT_MODEL_LABELS even if supplied', () => {
+    const result = normalizeModelLabels({
+      historicalItem: 'Object',
+      // @ts-expect-error — testing runtime behavior
+      bogusKey: 'should be ignored',
+    });
+    expect(Object.keys(result)).toEqual(Object.keys(DEFAULT_MODEL_LABELS));
+  });
+});
+
+describe('getDefaultModelLabelsConfig', () => {
+  it('returns a fresh labels object that callers can mutate without affecting defaults', () => {
+    const a = getDefaultModelLabelsConfig();
+    const b = getDefaultModelLabelsConfig();
+    expect(a.labels).not.toBe(b.labels);
+    a.labels.historicalItem = 'mutated';
+    expect(b.labels.historicalItem).toBe(DEFAULT_MODEL_LABELS.historicalItem);
+  });
+
+  it('matches DEFAULT_MODEL_LABELS for every key', () => {
+    const cfg = getDefaultModelLabelsConfig();
+    for (const key of Object.keys(DEFAULT_MODEL_LABELS) as ModelLabelKey[]) {
+      expect(cfg.labels[key]).toBe(DEFAULT_MODEL_LABELS[key]);
+    }
+  });
+});
+
+describe('pluralizeLabel', () => {
+  it('appends "s" for the simple case', () => {
+    expect(pluralizeLabel('Manuscript')).toBe('Manuscripts');
+    expect(pluralizeLabel('Item')).toBe('Items');
+  });
+
+  it('uses "ies" for words ending in consonant + y', () => {
+    expect(pluralizeLabel('City')).toBe('Cities');
+    expect(pluralizeLabel('Country')).toBe('Countries');
+  });
+
+  it('uses "s" (not "ies") for words ending in vowel + y', () => {
+    expect(pluralizeLabel('Day')).toBe('Days');
+    expect(pluralizeLabel('Boy')).toBe('Boys');
+  });
+
+  it('uses "es" for words ending in s, x, z, ch, sh', () => {
+    expect(pluralizeLabel('Box')).toBe('Boxes');
+    expect(pluralizeLabel('Bus')).toBe('Buses');
+    expect(pluralizeLabel('Buzz')).toBe('Buzzes');
+    expect(pluralizeLabel('Church')).toBe('Churches');
+    expect(pluralizeLabel('Bush')).toBe('Bushes');
+  });
+
+  it('handles uppercase suffixes the same way (case-insensitive match)', () => {
+    expect(pluralizeLabel('CITY')).toBe('CITies');
+    expect(pluralizeLabel('BOX')).toBe('BOXes');
+  });
+});

--- a/lib/site-features-server.ts
+++ b/lib/site-features-server.ts
@@ -4,20 +4,39 @@ import { getDefaultConfig, normalizeSectionOrder, type SiteFeaturesConfig } from
 
 const CONFIG_PATH = path.join(process.cwd(), 'config', 'site-features.json');
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
 export async function readSiteFeatures(): Promise<SiteFeaturesConfig> {
   const defaults = getDefaultConfig();
   try {
     const raw = await readFile(CONFIG_PATH, 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<SiteFeaturesConfig>;
+    const rawParsed: unknown = JSON.parse(raw);
+    // If the file was hand-edited to `null`, an array, or a primitive, we'd
+    // crash on `parsed.sections` reading below. Bail out to defaults so the
+    // SSR layout doesn't 500 the whole site over a broken config file.
+    if (!isPlainObject(rawParsed)) return defaults;
+    const parsed = rawParsed as Partial<SiteFeaturesConfig>;
+    // Defensive: spreading a string or array into an object produces
+    // index-keyed entries (e.g. {"0": "l", "1": "o"}) and pollutes the
+    // runtime config. Treat anything non-plain-object as missing so
+    // malformed config rows fall back to defaults instead of leaking
+    // garbage keys to consumers.
+    const parsedSections = isPlainObject(parsed.sections) ? parsed.sections : {};
+    const parsedCategories = isPlainObject(parsed.searchCategories) ? parsed.searchCategories : {};
     return {
-      sections: { ...defaults.sections, ...parsed.sections },
+      sections: { ...defaults.sections, ...parsedSections },
       sectionOrder: normalizeSectionOrder(parsed.sectionOrder),
       searchCategories: {
         ...defaults.searchCategories,
         ...Object.fromEntries(
-          Object.entries(parsed.searchCategories ?? {}).map(([k, v]) => [
+          Object.entries(parsedCategories).map(([k, v]) => [
             k,
-            { ...defaults.searchCategories[k as keyof typeof defaults.searchCategories], ...v },
+            {
+              ...defaults.searchCategories[k as keyof typeof defaults.searchCategories],
+              ...(isPlainObject(v) ? v : {}),
+            },
           ])
         ),
       },
@@ -27,12 +46,23 @@ export async function readSiteFeatures(): Promise<SiteFeaturesConfig> {
   }
 }
 
-export async function writeSiteFeatures(config: SiteFeaturesConfig): Promise<void> {
+export async function writeSiteFeatures(config: SiteFeaturesConfig): Promise<SiteFeaturesConfig> {
   const dir = path.dirname(CONFIG_PATH);
   await mkdir(dir, { recursive: true });
+  // Construct the normalized config from KNOWN keys only — `...config` would
+  // also write any extra keys a malicious or buggy payload included, slowly
+  // bloating the on-disk JSON with garbage. readSiteFeatures already
+  // ignores unknown keys when loading, so a strict whitelist here keeps
+  // both ends symmetric and the file pristine.
   const normalized: SiteFeaturesConfig = {
-    ...config,
+    sections: config.sections,
     sectionOrder: normalizeSectionOrder(config.sectionOrder),
+    searchCategories: config.searchCategories,
   };
   await writeFile(CONFIG_PATH, JSON.stringify(normalized, null, 2), 'utf-8');
+  // Return the normalized config so callers (e.g. the PUT route handler)
+  // can echo back exactly what was persisted. Returning the input verbatim
+  // would let the client's TanStack Query cache diverge from disk on
+  // every save — sectionOrder would silently differ until the next refetch.
+  return normalized;
 }

--- a/lib/site-features.test.ts
+++ b/lib/site-features.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_SECTION_KEYS,
+  getDefaultConfig,
+  normalizeSectionOrder,
+  type SectionKey,
+} from './site-features';
+
+describe('normalizeSectionOrder', () => {
+  it('returns the canonical order when input is undefined', () => {
+    expect(normalizeSectionOrder(undefined)).toEqual(ALL_SECTION_KEYS);
+  });
+
+  it('returns the canonical order when input is empty', () => {
+    expect(normalizeSectionOrder([])).toEqual(ALL_SECTION_KEYS);
+  });
+
+  it('honors a fully-specified custom order verbatim', () => {
+    const reversed = [...ALL_SECTION_KEYS].reverse();
+    expect(normalizeSectionOrder(reversed)).toEqual(reversed);
+  });
+
+  it('appends missing keys (in canonical order) after the user-provided ones', () => {
+    const partial: SectionKey[] = ['lightbox', 'collection'];
+    const result = normalizeSectionOrder(partial);
+    expect(result.slice(0, 2)).toEqual(['lightbox', 'collection']);
+    // The remaining keys appear in canonical order
+    const remaining = ALL_SECTION_KEYS.filter((k) => !partial.includes(k));
+    expect(result.slice(2)).toEqual(remaining);
+    expect(result).toHaveLength(ALL_SECTION_KEYS.length);
+  });
+
+  it('dedupes repeated keys, keeping the first occurrence', () => {
+    const dupes: SectionKey[] = ['lightbox', 'collection', 'lightbox', 'search'];
+    const result = normalizeSectionOrder(dupes);
+    expect(result.slice(0, 3)).toEqual(['lightbox', 'collection', 'search']);
+  });
+
+  it('drops unknown keys that aren’t in ALL_SECTION_KEYS', () => {
+    const result = normalizeSectionOrder(['lightbox', 'something-bogus' as SectionKey, 'about']);
+    expect(result.slice(0, 2)).toEqual(['lightbox', 'about']);
+    expect(result).toHaveLength(ALL_SECTION_KEYS.length);
+  });
+
+  it('always returns every canonical key exactly once', () => {
+    const messy: SectionKey[] = ['about', 'about', 'bogus' as SectionKey, 'lightbox'];
+    const result = normalizeSectionOrder(messy);
+    expect(result).toHaveLength(ALL_SECTION_KEYS.length);
+    expect(new Set(result)).toEqual(new Set(ALL_SECTION_KEYS));
+  });
+});
+
+describe('getDefaultConfig', () => {
+  it('enables every section by default', () => {
+    const cfg = getDefaultConfig();
+    for (const key of ALL_SECTION_KEYS) {
+      expect(cfg.sections[key]).toBe(true);
+    }
+  });
+
+  it('uses the canonical section order', () => {
+    expect(getDefaultConfig().sectionOrder).toEqual(ALL_SECTION_KEYS);
+  });
+
+  it('returns each search category enabled with non-empty defaults', () => {
+    const cfg = getDefaultConfig();
+    for (const cat of Object.values(cfg.searchCategories)) {
+      expect(cat.enabled).toBe(true);
+      expect(Array.isArray(cat.visibleColumns)).toBe(true);
+      expect(Array.isArray(cat.visibleFacets)).toBe(true);
+    }
+  });
+
+  it('returns fresh array instances so callers can mutate without affecting defaults', () => {
+    const a = getDefaultConfig();
+    const b = getDefaultConfig();
+    expect(a.sectionOrder).not.toBe(b.sectionOrder);
+    a.sectionOrder.push('lightbox');
+    expect(b.sectionOrder).toEqual(ALL_SECTION_KEYS);
+    // Same for the per-category arrays
+    const firstCat = Object.keys(a.searchCategories)[0]!;
+    expect(a.searchCategories[firstCat as keyof typeof a.searchCategories].visibleColumns).not.toBe(
+      b.searchCategories[firstCat as keyof typeof b.searchCategories].visibleColumns
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Small follow-up to the backoffice work: the two admin-only API routes (`/api/site-features` and `/api/model-labels`) and their server-side config helpers, plus unit tests for the normalization paths.

### Route refactors (`app/api/{site-features,model-labels}/route.ts`)

- Both routes now reach the API through the shared `authFetch` helper instead of hand-rolling `fetch + Authorization` headers, removing two near-duplicates of the auth-header dance.
- The site-features `PUT` now returns the **normalized** config (with `sectionOrder` canonicalized and unknown keys stripped). The client cache previously got back whatever it sent, so the in-memory state could quietly disagree with what's on disk.
- Permission gating is unchanged — site-features is still `is_staff`, model-labels is still `is_superuser`.

### Server helpers (`lib/{site-features,model-labels}-server.ts`)

- **Defensive read path**: a hand-edited config file that's `null`, an array, or otherwise non-object would have crashed the SSR layout on `.sections` / `.labels` reads. Now bails out to defaults so a corrupted file doesn't 500 the public site over a config typo.
- **Strict whitelist on write**: `writeSiteFeatures` constructs the persisted JSON from the known top-level keys only (`sections`, `sectionOrder`, `searchCategories`) instead of `...config`, so a buggy or malicious payload can't quietly fatten the on-disk file with garbage. Symmetric with the read path, which has always ignored unknown keys.
- Read-path defenses are technically client-affecting (SSR uses these helpers), but only on malformed input — valid configs read identically. Including them here keeps the helpers and routes coherent rather than splitting them across two PRs.

### Tests

Net-new, no existing test changed:
- `lib/site-features.test.ts`, `lib/model-labels.test.ts` — exercise the normalization helpers (default merge, sectionOrder canonicalization, model-label sanity).
- `contexts/site-features-context.test.tsx`, `contexts/model-labels-context.test.tsx` — provider behaviour: `initialConfig` is honoured, refetch swaps in fresh data, malformed responses fall back without crashing the consumer.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test --run` — 78 pass / 0 fail (12 test files)
- [x] `pnpm lint` — clean
- [ ] In dev, hit `/backoffice/site-features` as a staff user, change one section, save, refresh, confirm the value persisted and that the response matches what's on disk
- [ ] Hand-edit `config/site-features.json` to invalid JSON / `null`, reload the public homepage, confirm the layout doesn't 500 (defaults render instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
