### PR TITLE
feat(manuscripts/annotations): legacy-parity affordances on the annotations tab

### DIFF
--- a/app/(site)/manuscripts/[id]/images/[imageId]/annotations/page.tsx
+++ b/app/(site)/manuscripts/[id]/images/[imageId]/annotations/page.tsx
@@ -1,4 +1,9 @@
-import { fetchManuscriptImage, fetchAllographs, fetchHands } from '@/services/manuscripts';
+import {
+  fetchManuscriptImage,
+  fetchAllographs,
+  fetchHands,
+  fetchManuscript,
+} from '@/services/manuscripts';
 import { fetchAnnotationsForImage } from '@/services/annotations';
 import { AnnotationGallery } from '@/components/manuscript/annotation-gallery';
 
@@ -16,7 +21,7 @@ export default async function AnnotationsTabPage({ params }: PageProps) {
     return <div className="px-4 py-6 text-muted-foreground">Unable to load image.</div>;
   }
 
-  const [graphs, allographs, hands] = await Promise.all([
+  const [graphs, allographs, hands, manuscript] = await Promise.all([
     fetchAnnotationsForImage(imageId).catch(() => []),
     fetchAllographs().catch(() => []),
     fetchHands(image.item_part).catch(() => ({
@@ -25,6 +30,7 @@ export default async function AnnotationsTabPage({ params }: PageProps) {
       previous: null,
       results: [],
     })),
+    fetchManuscript(image.item_part).catch(() => null),
   ]);
 
   return (
@@ -32,7 +38,11 @@ export default async function AnnotationsTabPage({ params }: PageProps) {
       <AnnotationGallery
         manuscriptId={id}
         imageId={imageId}
+        itemImageId={image.id}
+        itemPartId={image.item_part}
         iiifImage={image.iiif_image}
+        locus={image.locus ?? ''}
+        shelfmark={manuscript?.display_label ?? ''}
         graphs={graphs}
         hands={hands.results}
         allographs={allographs}

--- a/components/manuscript/annotation-gallery.tsx
+++ b/components/manuscript/annotation-gallery.tsx
@@ -2,12 +2,24 @@
 
 import * as React from 'react';
 import Link from 'next/link';
+import { ArrowUp, ListChecks, Square, Star } from 'lucide-react';
+
 import { useIiifThumbnailUrl } from '@/hooks/use-iiif-thumbnail';
+import { useAuth } from '@/contexts/auth-context';
+import { useCollection, type CollectionItem } from '@/contexts/collection-context';
 import type { Allograph } from '@/types/allographs';
 import type { HandType } from '@/types/hands';
 import type { BackendGraph } from '@/services/annotations';
 import { formatAllographLabel } from '@/lib/allograph-labels';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
 
 interface AllographGroup {
   allographId: number;
@@ -55,13 +67,19 @@ function groupAnnotations(
   })).sort((a, b) => a.handName.localeCompare(b.handName));
 }
 
-interface AnnotationGalleryProps {
+// ---------------------------------------------------------------------------
+// Per-graph thumbnail
+// ---------------------------------------------------------------------------
+
+interface GraphThumbProps {
+  graph: BackendGraph;
+  iiifImage: string;
   manuscriptId: string;
   imageId: string;
-  iiifImage: string;
-  graphs: BackendGraph[];
-  hands: HandType[];
-  allographs: Allograph[];
+  isSelected: boolean;
+  onToggleSelected: () => void;
+  canEdit: boolean;
+  annotatingMode: boolean;
 }
 
 function GraphThumb({
@@ -69,58 +87,252 @@ function GraphThumb({
   iiifImage,
   manuscriptId,
   imageId,
-}: {
-  graph: BackendGraph;
-  iiifImage: string;
-  manuscriptId: string;
-  imageId: string;
-}) {
+  isSelected,
+  onToggleSelected,
+  canEdit,
+  annotatingMode,
+}: GraphThumbProps) {
   // Legacy GeoJSON polygons are stored with bottom-left origin (Web Mercator);
   // useIiifThumbnailUrl handles the y-flip and bounds clamping via info.json.
   const annotationJson = React.useMemo(() => JSON.stringify(graph.annotation), [graph.annotation]);
   const thumb = useIiifThumbnailUrl(iiifImage, annotationJson, 250);
   const href = `/manuscripts/${manuscriptId}/images/${imageId}?graph=${graph.id}`;
+  const tooltipLabel = canEdit ? 'Edit graph' : 'View graph in the manuscript viewer';
 
   return (
-    <Link
-      href={href}
+    <div
       className={cn(
-        'group flex flex-col items-center gap-1 rounded border bg-card p-2 transition',
-        'hover:border-primary'
+        'group relative flex flex-col gap-1 rounded border bg-card p-2 transition',
+        isSelected ? 'border-primary ring-2 ring-primary/40' : 'border-border hover:border-primary'
       )}
     >
-      <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded bg-muted">
-        {thumb ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={thumb}
-            alt={`Annotation ${graph.id}`}
-            className="max-h-full max-w-full object-contain"
-            loading="lazy"
-          />
-        ) : (
-          <span className="text-xs text-muted-foreground">…</span>
+      {/* Selection toggle: top-left corner, click anywhere on the box-edge to toggle. */}
+      <button
+        type="button"
+        onClick={onToggleSelected}
+        aria-pressed={isSelected}
+        aria-label={isSelected ? 'Unselect graph' : 'Select graph'}
+        className={cn(
+          'absolute left-1 top-1 z-10 flex h-5 w-5 items-center justify-center rounded border bg-background/80 text-[10px]',
+          isSelected
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-muted-foreground/40 opacity-60 group-hover:opacity-100'
         )}
-      </div>
-      <span className="text-xs text-muted-foreground group-hover:text-primary">#{graph.id}</span>
-    </Link>
+      >
+        {isSelected ? '✓' : ''}
+      </button>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            href={href}
+            className="flex h-24 w-24 items-center justify-center overflow-hidden rounded bg-muted"
+          >
+            {thumb ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={thumb}
+                alt={`Annotation ${graph.id}`}
+                className="max-h-full max-w-full object-contain"
+                loading="lazy"
+              />
+            ) : (
+              <span className="text-xs text-muted-foreground">…</span>
+            )}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+      </Tooltip>
+
+      {annotatingMode && <AnnotatingDetails graph={graph} />}
+    </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Annotating-mode inline detail (admin)
+// ---------------------------------------------------------------------------
+
+function AnnotatingDetails({ graph }: { graph: BackendGraph }) {
+  const components = graph.graphcomponent_set ?? [];
+  const positions = graph.position_details ?? [];
+
+  if (components.length === 0 && positions.length === 0) {
+    return (
+      <p className="mt-1 max-w-[10rem] text-center text-[10px] italic text-muted-foreground">
+        Undescribed
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-1 max-w-[10rem] space-y-1 text-[10px] leading-tight text-muted-foreground">
+      {components.map((c, i) => (
+        <div key={`${c.component}-${i}`}>
+          <span className="font-medium text-foreground">
+            {c.component_name ?? `#${c.component}`}
+          </span>
+          {c.feature_details && c.feature_details.length > 0 && (
+            <span> — {c.feature_details.map((f) => f.name).join(', ')}</span>
+          )}
+        </div>
+      ))}
+      {positions.length > 0 && (
+        <div className="italic">{positions.map((p) => p.name).join(', ')}</div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Anchor IDs
+// ---------------------------------------------------------------------------
+
 const handAnchorId = (handId: number | null) => `hand-${handId ?? 'unattributed'}`;
+
+// ---------------------------------------------------------------------------
+// Top-level component
+// ---------------------------------------------------------------------------
+
+interface AnnotationGalleryProps {
+  manuscriptId: string;
+  imageId: string;
+  itemImageId: number;
+  itemPartId: number;
+  iiifImage: string;
+  locus: string;
+  shelfmark: string;
+  graphs: BackendGraph[];
+  hands: HandType[];
+  allographs: Allograph[];
+}
 
 export function AnnotationGallery({
   manuscriptId,
   imageId,
+  itemImageId,
+  itemPartId,
   iiifImage,
+  locus,
+  shelfmark,
   graphs,
   hands,
   allographs,
 }: AnnotationGalleryProps) {
+  const { user } = useAuth();
+  const { addItem, isInCollection } = useCollection();
+  const canEdit = Boolean(user?.is_staff);
+
+  const [selectedIds, setSelectedIds] = React.useState<Set<number>>(new Set());
+  const [allographFilter, setAllographFilter] = React.useState('');
+  const [annotatingMode, setAnnotatingMode] = React.useState(false);
+  const [showBackToTop, setShowBackToTop] = React.useState(false);
+
+  // Show back-to-top once the user has scrolled meaningfully past the fold.
+  // 600px is "past the Hands TOC and the first hand's allograph header on a
+  // typical 1080p viewport" — a button that appears immediately would just
+  // crowd the top of the page.
+  React.useEffect(() => {
+    const onScroll = () => setShowBackToTop(window.scrollY > 600);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   const groups = React.useMemo(
     () => groupAnnotations(graphs, hands, allographs),
     [graphs, hands, allographs]
   );
+
+  // Apply allograph filter (substring, case-insensitive) — drop allograph
+  // groups whose name doesn't match, then drop hand groups left empty.
+  const filteredGroups = React.useMemo(() => {
+    const needle = allographFilter.trim().toLowerCase();
+    if (!needle) return groups;
+    return groups
+      .map((handGroup) => ({
+        ...handGroup,
+        allographs: handGroup.allographs.filter((a) =>
+          a.allographName.toLowerCase().includes(needle)
+        ),
+      }))
+      .filter((handGroup) => handGroup.allographs.length > 0);
+  }, [groups, allographFilter]);
+
+  const selectionCount = selectedIds.size;
+
+  const toggleGraph = React.useCallback((id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectAllInGroup = React.useCallback((groupGraphs: BackendGraph[]) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const g of groupGraphs) next.add(g.id);
+      return next;
+    });
+  }, []);
+
+  const unselectAllInGroup = React.useCallback((groupGraphs: BackendGraph[]) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const g of groupGraphs) next.delete(g.id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = React.useCallback(() => setSelectedIds(new Set()), []);
+
+  // Build a CollectionItem from a graph. The page passes through
+  // shelfmark/locus/iiif so the collection drawer can render the same
+  // metadata it does for graphs added from the search results.
+  const buildCollectionItem = React.useCallback(
+    (graph: BackendGraph): CollectionItem => ({
+      id: graph.id,
+      type: 'graph',
+      item_part: itemPartId,
+      item_image: itemImageId,
+      image_iiif: iiifImage,
+      coordinates: JSON.stringify(graph.annotation),
+      shelfmark,
+      locus,
+    }),
+    [iiifImage, itemImageId, itemPartId, locus, shelfmark]
+  );
+
+  const addGroupToCollection = React.useCallback(
+    (groupGraphs: BackendGraph[]) => {
+      let added = 0;
+      for (const g of groupGraphs) {
+        if (!selectedIds.has(g.id)) continue;
+        if (isInCollection(g.id, 'graph')) continue;
+        addItem(buildCollectionItem(g));
+        added += 1;
+      }
+      return added;
+    },
+    [addItem, buildCollectionItem, isInCollection, selectedIds]
+  );
+
+  const addAllSelectedToCollection = React.useCallback(() => {
+    let added = 0;
+    for (const handGroup of groups) {
+      for (const allographGroup of handGroup.allographs) {
+        for (const g of allographGroup.graphs) {
+          if (!selectedIds.has(g.id)) continue;
+          if (isInCollection(g.id, 'graph')) continue;
+          addItem(buildCollectionItem(g));
+          added += 1;
+        }
+      }
+    }
+    return added;
+  }, [addItem, buildCollectionItem, groups, isInCollection, selectedIds]);
 
   if (groups.length === 0) {
     return (
@@ -131,68 +343,203 @@ export function AnnotationGallery({
   }
 
   return (
-    <div className="space-y-8">
-      {groups.length > 1 && (
-        <nav aria-label="Hands on this image">
-          <h2 className="text-base font-semibold">Hands</h2>
-          <ul className="mt-2 flex flex-wrap gap-2 text-sm">
-            {groups.map((g) => (
-              <li key={g.handId ?? 'unattributed'}>
-                <a
-                  href={`#${handAnchorId(g.handId)}`}
-                  className="rounded border bg-card px-2 py-1 hover:border-primary"
-                >
-                  {g.handName}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-      )}
+    <TooltipProvider delayDuration={200}>
+      <div className="space-y-8">
+        {/* Top toolbar — filter + (admin) annotating-mode toggle + cross-group selection summary. */}
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card px-3 py-2">
+          <div className="flex flex-1 items-center gap-3">
+            <Input
+              type="search"
+              placeholder="Filter allographs…"
+              value={allographFilter}
+              onChange={(e) => setAllographFilter(e.target.value)}
+              className="h-8 max-w-xs"
+              aria-label="Filter allographs by name"
+            />
+            {canEdit && (
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Switch
+                  checked={annotatingMode}
+                  onCheckedChange={setAnnotatingMode}
+                  aria-label="Annotating mode"
+                />
+                Annotating mode
+              </label>
+            )}
+          </div>
 
-      {groups.map((handGroup) => {
-        const anchorId = handAnchorId(handGroup.handId);
-        return (
-          <section key={anchorId} id={anchorId}>
-            <h2 className="text-lg font-semibold">{handGroup.handName}</h2>
-            <ul className="mt-1 mb-3 flex flex-wrap gap-2 text-sm">
-              {handGroup.allographs.map((a) => (
-                <li key={a.allographId}>
+          {selectionCount > 0 && (
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-muted-foreground">{selectionCount} selected</span>
+              <Button
+                size="sm"
+                variant="default"
+                onClick={() => addAllSelectedToCollection()}
+                className="h-7 gap-1.5"
+              >
+                <Star className="h-3.5 w-3.5" />
+                Add to collection
+              </Button>
+              <Button size="sm" variant="ghost" onClick={clearSelection} className="h-7">
+                Clear
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {/* Hands TOC — only useful when there are 2+ hands to choose between. */}
+        {filteredGroups.length > 1 && (
+          <nav aria-label="Hands on this image">
+            <h2 className="text-base font-semibold">Hands</h2>
+            <ul className="mt-2 flex flex-wrap gap-2 text-sm">
+              {filteredGroups.map((g) => (
+                <li key={g.handId ?? 'unattributed'}>
                   <a
-                    href={`#${anchorId}-allograph-${a.allographId}`}
-                    className="rounded border bg-muted px-2 py-0.5 text-muted-foreground hover:border-primary hover:text-foreground"
+                    href={`#${handAnchorId(g.handId)}`}
+                    className="rounded border bg-card px-2 py-1 hover:border-primary"
                   >
-                    {a.allographName} ({a.graphs.length})
+                    {g.handName}
                   </a>
                 </li>
               ))}
             </ul>
+          </nav>
+        )}
 
-            <div className="space-y-6">
-              {handGroup.allographs.map((allographGroup) => (
-                <div
-                  key={allographGroup.allographId}
-                  id={`${anchorId}-allograph-${allographGroup.allographId}`}
-                  className="space-y-2"
-                >
-                  <h3 className="text-sm font-medium">{allographGroup.allographName}</h3>
-                  <div className="flex flex-wrap gap-2">
-                    {allographGroup.graphs.map((graph) => (
-                      <GraphThumb
-                        key={graph.id}
-                        graph={graph}
-                        iiifImage={iiifImage}
-                        manuscriptId={manuscriptId}
-                        imageId={imageId}
-                      />
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-        );
-      })}
-    </div>
+        {filteredGroups.length === 0 && allographFilter.trim() && (
+          <p className="text-sm text-muted-foreground">
+            No allographs match &ldquo;{allographFilter.trim()}&rdquo;.
+          </p>
+        )}
+
+        {filteredGroups.map((handGroup) => {
+          const anchorId = handAnchorId(handGroup.handId);
+          return (
+            <section key={anchorId} id={anchorId}>
+              <h2 className="text-lg font-semibold">{handGroup.handName}</h2>
+
+              {/* Allograph quick-jump badges inside this hand. */}
+              <ul className="mt-1 mb-3 flex flex-wrap gap-2 text-sm">
+                {handGroup.allographs.map((a) => (
+                  <li key={a.allographId}>
+                    <a
+                      href={`#${anchorId}-allograph-${a.allographId}`}
+                      className="rounded border bg-muted px-2 py-0.5 text-muted-foreground hover:border-primary hover:text-foreground"
+                    >
+                      {a.allographName} ({a.graphs.length})
+                    </a>
+                  </li>
+                ))}
+              </ul>
+
+              <div className="space-y-6">
+                {handGroup.allographs.map((allographGroup) => {
+                  const groupSelectedCount = allographGroup.graphs.filter((g) =>
+                    selectedIds.has(g.id)
+                  ).length;
+                  const allSelected =
+                    groupSelectedCount > 0 && groupSelectedCount === allographGroup.graphs.length;
+
+                  return (
+                    <div
+                      key={allographGroup.allographId}
+                      id={`${anchorId}-allograph-${allographGroup.allographId}`}
+                      className="space-y-2"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <h3 className="text-sm font-medium">
+                          {allographGroup.allographName}{' '}
+                          <span className="text-xs font-normal text-muted-foreground">
+                            ({allographGroup.graphs.length})
+                          </span>
+                        </h3>
+
+                        {/* Per-allograph toolbar: Select all / Unselect all / Add to collection. */}
+                        <div className="flex items-center gap-1">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-7 gap-1.5 text-xs"
+                            onClick={() =>
+                              allSelected
+                                ? unselectAllInGroup(allographGroup.graphs)
+                                : selectAllInGroup(allographGroup.graphs)
+                            }
+                          >
+                            {allSelected ? (
+                              <>
+                                <Square className="h-3.5 w-3.5" />
+                                Unselect all
+                              </>
+                            ) : (
+                              <>
+                                <ListChecks className="h-3.5 w-3.5" />
+                                Select all
+                              </>
+                            )}
+                          </Button>
+
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 gap-1.5 text-xs"
+                                disabled={groupSelectedCount === 0}
+                                onClick={() => addGroupToCollection(allographGroup.graphs)}
+                              >
+                                <Star className="h-3.5 w-3.5" />
+                                Add selected
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="top">
+                              Add selected graphs to collection
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        {allographGroup.graphs.map((graph) => (
+                          <GraphThumb
+                            key={graph.id}
+                            graph={graph}
+                            iiifImage={iiifImage}
+                            manuscriptId={manuscriptId}
+                            imageId={imageId}
+                            isSelected={selectedIds.has(graph.id)}
+                            onToggleSelected={() => toggleGraph(graph.id)}
+                            canEdit={canEdit}
+                            annotatingMode={annotatingMode}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+
+        {/* Floating back-to-top — appears once the user has scrolled past the fold. */}
+        {showBackToTop && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon"
+                variant="default"
+                className="fixed bottom-6 right-6 z-50 h-10 w-10 rounded-full shadow-lg"
+                onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                aria-label="Back to top"
+              >
+                <ArrowUp className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="left">Back to top</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## Summary

Brings the manuscript-image annotations tab (`/manuscripts/<id>/images/<imageId>/annotations`) to feature parity with the legacy DigiPal `/page/<id>/allographs/` view that researchers have been asking after.

### Selection & collection
- Each thumbnail has a top-left **selection toggle**.
- Each allograph group header gets a **"Select all" / "Unselect all"** button (it flips state when the group is fully selected).
- Each allograph group header gets an **"Add selected"** star button (disabled until at least one graph in that group is selected).
- The top toolbar shows a **cross-group selection summary** with "Add to collection" / "Clear" actions, so a user who's been ticking graphs across multiple allographs can ship the whole batch in one click.
- All wiring goes through the existing `useCollection`, deduping with `isInCollection`.

### Wayfinding
- **Filter allographs** input at the top, case-insensitive substring match. Hides empty hand groups and renders a "no allographs match" state when nothing's left.
- **Back-to-top floating anchor** appears once `scrollY > 600px`, smooth-scrolls home.

### Affordance
- **Tooltips** on each thumbnail: "Edit graph" for `user.is_staff`, "View graph in the manuscript viewer" otherwise. Radix-driven; matches the legacy Bootstrap tooltip copy.

### Annotating mode (staff)
- New **switch in the top toolbar** (only rendered for `user?.is_staff`). When on, each thumbnail card grows an inline `AnnotatingDetails` block listing components (with their feature names) and positions, or "Undescribed" when both lists are empty. Lets editors audit descriptions without opening every graph in the editor one by one.

### Page wiring
The page passes the additional `itemImageId`, `itemPartId`, `locus`, and `shelfmark` props through so the `CollectionItem` payload matches what the search results add — the collection drawer renders the same metadata for both sources.

## Reference

- Legacy template: `legacy/digipal/templates/digipal/annotations.html`
- Legacy doc: `legacy/digipal/doc/annotation-process.md`

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] Manual: page renders 200 against the dev server with annotations on `/manuscripts/706/images/45/annotations`
- [ ] Toggle the selection checkmark, verify per-group "Select all" mass-toggles
- [ ] Add a selection to the collection drawer; confirm the entries carry `image_iiif`/`coordinates`/`shelfmark`/`locus` like the search-results path
- [ ] Type "long s" into the filter, confirm only matching allograph groups remain (and any hand without a match vanishes)
- [ ] Log in as `ahmed`/`123`, toggle "Annotating mode", confirm each card shows components / features / positions inline; toggle off, confirm cards collapse back to plain thumbnails
- [ ] Hover a thumbnail anonymous → "View graph…", logged-in staff → "Edit graph"
- [ ] Scroll past 600 px, confirm the back-to-top button appears; click, confirm smooth scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)
