### PR TITLE
Fix SIPI v5 IIIF thumbnail crops

### DIFF
--- a/components/manuscript/allograph-gallery-dialog.tsx
+++ b/components/manuscript/allograph-gallery-dialog.tsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 
-import { getIiifBaseUrl, getSelectorValue, iiifThumbFromSelector } from '@/utils/iiif';
+import {
+  fetchIiifImageInfo,
+  getIiifBaseUrl,
+  getSelectorValue,
+  iiifThumbFromSelector,
+} from '@/utils/iiif';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { ResizeHandle } from '@/components/ui/resize-handle';
 import { Separator } from '@/components/ui/separator';
@@ -10,6 +15,7 @@ import { Separator } from '@/components/ui/separator';
 import type { Annotation as A9sAnnotation } from './manuscript-annotorious';
 
 import { browserSafeIiifUrl } from '@/lib/annotation-popup-utils';
+import type { IIIFImageInfo } from '@/utils/iiif';
 
 export interface AllographGalleryDialogProps {
   open: boolean;
@@ -42,6 +48,31 @@ export function AllographGalleryDialog({
   height,
   resizeHandleProps,
 }: AllographGalleryDialogProps) {
+  const iiifBase = iiifImage ? browserSafeIiifUrl(getIiifBaseUrl(iiifImage)) : null;
+  const iiifInfoKey = open && iiifBase ? iiifBase : '';
+  const [iiifInfoState, setIiifInfoState] = React.useState<{
+    key: string;
+    info: IIIFImageInfo | null;
+  } | null>(null);
+  const iiifInfo = iiifInfoState?.key === iiifInfoKey ? iiifInfoState.info : undefined;
+
+  React.useEffect(() => {
+    if (!iiifInfoKey) return;
+
+    let cancelled = false;
+    fetchIiifImageInfo(iiifInfoKey)
+      .then((info) => {
+        if (!cancelled) setIiifInfoState({ key: iiifInfoKey, info });
+      })
+      .catch(() => {
+        if (!cancelled) setIiifInfoState({ key: iiifInfoKey, info: null });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [iiifInfoKey]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange} modal={false}>
       <DialogContent
@@ -79,10 +110,9 @@ export function AllographGalleryDialog({
           <div className="grid grid-cols-4 gap-3">
             {annotations.map((annotation) => {
               const selector = getSelectorValue(annotation);
-              if (!selector || !iiifImage) return null;
+              if (!selector || !iiifBase || iiifInfo == null) return null;
 
-              const base = browserSafeIiifUrl(getIiifBaseUrl(iiifImage));
-              const src = iiifThumbFromSelector(base, selector, 200);
+              const src = iiifThumbFromSelector(iiifBase, selector, 200, iiifInfo);
               if (!src) return null;
 
               return (

--- a/components/manuscript/manuscript-viewer.test.tsx
+++ b/components/manuscript/manuscript-viewer.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Allograph } from '@/types/allographs';
 
@@ -129,8 +129,22 @@ const allographB = {
 };
 
 describe('ManuscriptViewer smoke test', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ width: 1000, height: 2000 }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+      )
+    );
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('mounts past the loading state and renders the image-tools header control', async () => {

--- a/utils/iiif.test.ts
+++ b/utils/iiif.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getIiifImageUrl, getIiifImageUrlWithBounds, iiifThumbFromSelector } from './iiif';
+
+const BASE_URL = 'http://localhost:1024/4w108287_89_90_91_92p%2Fa80128_37.jp2';
+const INFO_URL = `${BASE_URL}/info.json`;
+const BOUNDS = { width: 5468, height: 6471 };
+const EXPECTED_PCT_REGION = 'pct:8.778,9.396,4.188,4.482';
+
+describe('IIIF thumbnail URL generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps full-image thumbnails on the old width-based IIIF size form', () => {
+    expect(getIiifImageUrl(INFO_URL, { thumbnail: true })).toBe(
+      `${BASE_URL}/full/300,/0/default.jpg`
+    );
+  });
+
+  it('uses best-fit size for cropped thumbnails instead of max', () => {
+    expect(
+      getIiifImageUrl(INFO_URL, {
+        coordinates: { x: 480, y: 608, w: 229, h: 290 },
+        thumbnail: true,
+        maxSize: 200,
+      })
+    ).toBe(`${BASE_URL}/480,608,229,290/!200,200/0/default.jpg`);
+  });
+
+  it('converts selector crops to percentage regions when image bounds are known', () => {
+    expect(iiifThumbFromSelector(BASE_URL, 'xywh=pixel:480,608,229,290', 200, BOUNDS)).toBe(
+      `${BASE_URL}/${EXPECTED_PCT_REGION}/!200,200/0/default.jpg`
+    );
+  });
+
+  it('converts bounded GeoJSON crops to the same percentage region after Y flip', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        return new Response(JSON.stringify(BOUNDS), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      })
+    );
+
+    await expect(
+      getIiifImageUrlWithBounds(INFO_URL, {
+        coordinates: { x: 480, y: 5573, w: 229, h: 290 },
+        thumbnail: true,
+        flipY: true,
+        maxSize: 200,
+      })
+    ).resolves.toBe(`${BASE_URL}/${EXPECTED_PCT_REGION}/!200,200/0/default.jpg`);
+  });
+
+  it('clamps signed selector coordinates before building fallback pixel-region crops', () => {
+    expect(iiifThumbFromSelector(BASE_URL, 'xywh=pixel:-10,-2,30,40', 200)).toBe(
+      `${BASE_URL}/0,0,30,40/!200,200/0/default.jpg`
+    );
+  });
+});

--- a/utils/iiif.ts
+++ b/utils/iiif.ts
@@ -132,7 +132,8 @@ function clampCoordinatesToBounds(
 }
 
 function parseXywh(value: string): IIIFCoordinates | null {
-  const m = value.match(/xywh=pixel:([\d.]+),([\d.]+),([\d.]+),([\d.]+)/);
+  const n = '-?\\d+(?:\\.\\d+)?';
+  const m = value.match(new RegExp(`xywh=pixel:(${n}),(${n}),(${n}),(${n})`));
   if (!m) return null;
   return { x: Number(m[1]), y: Number(m[2]), w: Number(m[3]), h: Number(m[4]) };
 }
@@ -143,6 +144,37 @@ function clampXywh(
 ): { region: string } {
   const clamped = clampCoordinatesToBounds(xywh, bounds);
   return { region: `${clamped.x},${clamped.y},${clamped.w},${clamped.h}` };
+}
+
+function formatPct(value: number): string {
+  return value.toFixed(3).replace(/\.?0+$/, '');
+}
+
+function pctRegionFromCoordinates(
+  coords: IIIFCoordinates,
+  bounds: { width: number; height: number }
+): string {
+  const x = (coords.x / bounds.width) * 100;
+  const y = (coords.y / bounds.height) * 100;
+  const w = (coords.w / bounds.width) * 100;
+  const h = (coords.h / bounds.height) * 100;
+  return `pct:${formatPct(x)},${formatPct(y)},${formatPct(w)},${formatPct(h)}`;
+}
+
+function thumbnailPixelSize(options?: IIIFImageUrlOptions): number {
+  return typeof options?.maxSize === 'number' && options.maxSize > 0
+    ? Math.round(options.maxSize)
+    : DEFAULT_THUMBNAIL_SIZE;
+}
+
+function thumbnailSizePart(options?: IIIFImageUrlOptions, cropped = false): string {
+  const size = thumbnailPixelSize(options);
+  return cropped ? `!${size},${size}` : `${size},`;
+}
+
+function fixedThumbnailSizePart(size: number): string {
+  const pixelSize = Number.isFinite(size) && size > 0 ? Math.round(size) : DEFAULT_THUMBNAIL_SIZE;
+  return `!${pixelSize},${pixelSize}`;
 }
 
 // --- Public API ---
@@ -160,18 +192,14 @@ export function iiifThumbFromSelector(
   iiifBase: string,
   selectorValue: string,
   size = 200,
-  bounds?: { width?: number; height?: number }
+  bounds?: IIIFImageInfo | null
 ): string | null {
   const xywh = parseXywh(selectorValue);
   if (!xywh) return null;
-  // Clamp against the real image dimensions when the caller has them (one
-  // info.json fetch serves every thumbnail sharing the same iiifBase), so a
-  // region whose x+w / y+h overflows the page can't produce an out-of-range
-  // IIIF region string that a 3.0-strict server may reject. When bounds are
-  // unknown this still rounds/floors as before.
-  const { region } = clampXywh(xywh, bounds);
+  const clamped = clampCoordinatesToBounds(xywh, bounds ?? undefined);
+  const region = bounds ? pctRegionFromCoordinates(clamped, bounds) : clampXywh(clamped).region;
   const base = normalizeIiifBase(iiifBase);
-  const sizePart = xywh.w < size ? 'max' : `${size},`;
+  const sizePart = fixedThumbnailSizePart(size);
   return `${base}/${region}/${sizePart}/0/default.jpg`;
 }
 
@@ -183,12 +211,7 @@ export function getIiifImageUrl(infoUrl: string, options?: IIIFImageUrlOptions):
     : 'full';
   let size: string;
   if (options?.thumbnail) {
-    const regionW = options?.coordinates?.w;
-    if (typeof regionW === 'number' && regionW > 0 && regionW < DEFAULT_THUMBNAIL_SIZE) {
-      size = 'max';
-    } else {
-      size = `${DEFAULT_THUMBNAIL_SIZE},`;
-    }
+    size = thumbnailSizePart(options, options.coordinates != null);
   } else if (typeof options?.maxSize === 'number' && options.maxSize > 0) {
     size = `!${options.maxSize},${options.maxSize}`;
   } else {
@@ -258,6 +281,12 @@ export async function getIiifImageUrlWithBounds(
       width: bounds.width,
       height: bounds.height,
     });
+    if (options.thumbnail) {
+      const base = normalizeIiifBase(resolveInfoUrl(infoUrl));
+      const region = pctRegionFromCoordinates(coordinates, bounds);
+      const size = thumbnailSizePart(options, true);
+      return `${base}/${region}/${size}/0/default.jpg`;
+    }
   }
   return getIiifImageUrl(infoUrl, { ...options, coordinates });
 }


### PR DESCRIPTION
## Summary
- Generate bounded cropped IIIF thumbnails as `pct:` region URLs for SIPI v5 compatibility
- Keep full-page thumbnails on the existing width-based IIIF size form
- Fetch IIIF image bounds for allograph popup thumbnails
- Add regression coverage for cropped and full-page thumbnail URL shapes

## Verification
- pnpm test utils/iiif.test.ts
- pnpm exec eslint utils/iiif.ts utils/iiif.test.ts components/manuscript/allograph-gallery-dialog.tsx
- pnpm exec prettier --check utils/iiif.ts utils/iiif.test.ts components/manuscript/allograph-gallery-dialog.tsx
- Local SIPI returned thumbnail-sized JPEGs for the generated crop/full-page URLs