### PR TITLE
Feat/csp nonce

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import localFont from 'next/font/local';
 import { Lora, Cormorant_Garamond } from 'next/font/google';
 import { Toaster } from 'sonner';
@@ -69,6 +70,8 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const requestHeaders = await headers();
+  const nonce = requestHeaders.get('x-nonce') ?? undefined;
   const [siteFeaturesConfig, modelLabelsConfig] = await Promise.all([
     readSiteFeatures(),
     readModelLabels(),
@@ -77,6 +80,7 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
+        data-csp-nonce={nonce}
         className={`${geistSans.variable} ${geistMono.variable} ${lora.variable} ${cormorant.variable} ${junicode.variable} antialiased`}
       >
         <AuthProvider>

--- a/components/collection/print-collection-button.tsx
+++ b/components/collection/print-collection-button.tsx
@@ -5,6 +5,7 @@ import { Printer } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
+import { readDocumentNonce } from '@/lib/csp-nonce';
 import { buildCollectionPrintHtml } from '@/lib/collection-print';
 import type { NamedCollection } from '@/lib/collection-storage';
 
@@ -31,7 +32,10 @@ export function PrintCollectionButton({ collection }: { collection: NamedCollect
     );
 
     try {
-      writePrintDocument(win, await buildCollectionPrintHtml(collection));
+      writePrintDocument(
+        win,
+        await buildCollectionPrintHtml(collection, { nonce: readDocumentNonce() })
+      );
     } catch {
       win.close();
       toast.error('Could not prepare collection print view.');

--- a/components/lightbox/lightbox-export.tsx
+++ b/components/lightbox/lightbox-export.tsx
@@ -175,6 +175,11 @@ export function LightboxExport({ onClose }: LightboxExportProps) {
       toast.error('Pop-up blocked — allow pop-ups for this site to print.');
       return;
     }
+    const handleLoad = () => {
+      win.focus();
+      win.print();
+    };
+    win.addEventListener('load', handleLoad, { once: true });
     const figures = workspaceImages
       .map((img) => {
         const caption = getLightboxImageCaption(img);
@@ -193,7 +198,7 @@ export function LightboxExport({ onClose }: LightboxExportProps) {
         `img { width: 100%; height: auto; object-fit: contain; }` +
         `figcaption { font-size: 11px; color: #333; margin-top: 6px; }` +
         `</style></head>` +
-        `<body onload="window.focus();window.print();">` +
+        `<body>` +
         `<h1>Models of Authority — Lightbox (${count} image${count === 1 ? '' : 's'})</h1>` +
         `<div class="grid">${figures}</div>` +
         `</body></html>`

--- a/lib/collection-print.test.ts
+++ b/lib/collection-print.test.ts
@@ -117,4 +117,16 @@ describe('buildCollectionPrintHtml', () => {
     expect(html).not.toContain('javascript:');
     expect(html.match(/No image available/g)).toHaveLength(2);
   });
+
+  it('adds a nonce to the startup script when one is provided', async () => {
+    const collection: NamedCollection = {
+      id: 'nonce-test',
+      name: 'Nonce test',
+      items: [],
+    };
+
+    const html = await buildCollectionPrintHtml(collection, { nonce: 'nonce-value' });
+
+    expect(html).toContain('<script nonce="nonce-value">');
+  });
 });

--- a/lib/collection-print.ts
+++ b/lib/collection-print.ts
@@ -50,9 +50,10 @@ async function getPrintImageUrl(item: CollectionItem): Promise<string> {
   });
 }
 
-function buildPrintStartupScript(): string {
+function buildPrintStartupScript(nonce?: string): string {
+  const nonceAttribute = nonce ? ` nonce="${escapeHtml(nonce)}"` : '';
   return `
-    <script>
+    <script${nonceAttribute}>
       (function () {
         function retryUrl(src) {
           try {
@@ -163,7 +164,10 @@ async function buildPrintTableRow(item: CollectionItem, index: number): Promise<
   );
 }
 
-export async function buildCollectionPrintHtml(collection: NamedCollection): Promise<string> {
+export async function buildCollectionPrintHtml(
+  collection: NamedCollection,
+  options?: { nonce?: string }
+): Promise<string> {
   const sections = await Promise.all(
     groupItemsBySection(collection).map(async ([sectionType, items]) => {
       const rows = await Promise.all(items.map(buildPrintTableRow));
@@ -184,7 +188,7 @@ export async function buildCollectionPrintHtml(collection: NamedCollection): Pro
   const count = collection.items.length;
 
   return (
-    `<!doctype html><html><head><meta charset="utf-8">` +
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
     `<title>${escapeHtml(collection.name)} · Collection print</title>` +
     `<style>` +
     `@page { margin: 12mm; }` +
@@ -209,7 +213,7 @@ export async function buildCollectionPrintHtml(collection: NamedCollection): Pro
     `<h1>${escapeHtml(collection.name)}</h1>` +
     `<p class="summary">Models of Authority collection · ${count} ${count === 1 ? 'item' : 'items'}</p>` +
     `${sections.join('')}` +
-    `${buildPrintStartupScript()}` +
+    `${buildPrintStartupScript(options?.nonce)}` +
     `</body></html>`
   );
 }

--- a/lib/csp-nonce.ts
+++ b/lib/csp-nonce.ts
@@ -1,0 +1,4 @@
+export function readDocumentNonce(doc: Document = document): string | undefined {
+  const nonce = doc.body?.dataset.cspNonce?.trim() || doc.documentElement?.dataset.cspNonce?.trim();
+  return nonce || undefined;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -18,12 +18,12 @@ const SECTION_ROUTE_MAP: Partial<Record<SectionKey, string>> = {
 // CSP / security-header concerns previously lived in middleware.ts. Next 16
 // requires middleware to be merged into proxy.ts, so they ride along here.
 // Dev keeps 'unsafe-inline'/'unsafe-eval' so React Fast Refresh works; prod
-// uses a per-request nonce with strict-dynamic.
+// keeps nonce support but allows same-origin script chunks explicitly.
 function buildCsp(nonce: string): string {
   const directives: string[] = [
     "default-src 'self'",
     isProduction
-      ? `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`
+      ? `script-src 'self' 'nonce-${nonce}'`
       : `script-src 'self' 'unsafe-inline' 'unsafe-eval'`,
     "style-src 'self' 'unsafe-inline'",
     isProduction ? "img-src 'self' data: blob: https:" : "img-src 'self' data: blob: https: http:",


### PR DESCRIPTION
This pull request introduces support for Content Security Policy (CSP) nonces to enhance script security, especially for print views, and refines how print windows are handled. The main changes include propagating a per-request CSP nonce from the server to client-side print scripts, updating the print window logic, and improving test coverage for nonce handling.

**CSP Nonce Propagation and Usage:**

- The CSP nonce is now read from the request headers in `app/layout.tsx` and attached to the document as a `data-csp-nonce` attribute, making it accessible to client-side scripts (`app/layout.tsx`) [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR2) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR73-R74) [[3]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR83).
- A new utility, `readDocumentNonce`, is added to retrieve the nonce from the DOM (`lib/csp-nonce.ts`).
- The print HTML builder (`buildCollectionPrintHtml`) and its startup script now accept and embed the nonce, ensuring inline scripts are CSP-compliant (`lib/collection-print.ts`, `components/collection/print-collection-button.tsx`) [[1]](diffhunk://#diff-65ccfcf249b1037716387148af4028d9310745e3faf5ba46fb322a0936407483L166-R170) [[2]](diffhunk://#diff-65ccfcf249b1037716387148af4028d9310745e3faf5ba46fb322a0936407483L212-R216) [[3]](diffhunk://#diff-98181f09a02b31375074ad393dc928acdcb6c67dc11dd081849a10dbcc248b60R8) [[4]](diffhunk://#diff-98181f09a02b31375074ad393dc928acdcb6c67dc11dd081849a10dbcc248b60L34-R38).

**Print Window Handling Improvements:**

- The `LightboxExport` component now attaches a `load` event handler to the print window for reliable printing, instead of relying on the `onload` attribute in the HTML (`components/lightbox/lightbox-export.tsx`) [[1]](diffhunk://#diff-51b3087bd02c5c4d03255ed1ccd52f6521fdfd59c68617257411b099f0d5f9eeR178-R182) [[2]](diffhunk://#diff-51b3087bd02c5c4d03255ed1ccd52f6521fdfd59c68617257411b099f0d5f9eeL196-R201).

**Testing and Miscellaneous:**

- Added a test to ensure that the nonce is correctly added to the print script (`lib/collection-print.test.ts`).
- The CSP header construction in `proxy.ts` is updated to clarify nonce handling and remove `strict-dynamic` from production (`proxy.ts`).

These changes collectively improve the security and reliability of print-related features by ensuring inline scripts work seamlessly with CSP nonces.