### PR TITLE
Graph search: add S/M/L thumbnail-size control to results grid

### DIFF
--- a/components/search/search-grid.tsx
+++ b/components/search/search-grid.tsx
@@ -12,6 +12,7 @@ import { CollectionStar } from '@/components/collection/collection-star';
 import { OpenLightboxButton } from '@/components/lightbox/open-lightbox-button';
 import { getImageDetailUrl } from '@/lib/media-url';
 import { GraphDetailLink } from '@/components/search/graph-detail-link';
+import type { ThumbnailSize } from '@/components/search/thumbnail-size-control';
 
 type GridItem = ImageListItem | GraphListItem | ManuscriptListItem;
 
@@ -20,7 +21,17 @@ export interface SearchGridProps {
   resultType: ResultType;
   highlightKeyword?: string;
   isFetching?: boolean;
+  thumbnailSize?: ThumbnailSize;
 }
+
+// Column counts per thumbnail size. 'medium' preserves the historical grid;
+// 'small'/'large' add or remove columns to shrink/grow each cell. Full static
+// class strings so Tailwind's JIT can see them.
+const GRID_COLUMNS: Record<ThumbnailSize, string> = {
+  small: 'grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10',
+  medium: 'grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6',
+  large: 'grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4',
+};
 
 type GridCard =
   | {
@@ -289,6 +300,7 @@ function SearchGridComponent({
   resultType,
   highlightKeyword = '',
   isFetching = false,
+  thumbnailSize = 'medium',
 }: SearchGridProps) {
   const cards = React.useMemo(
     () => results.map((item) => ({ card: toGridCard(resultType, item) })),
@@ -354,7 +366,7 @@ function SearchGridComponent({
 
   return (
     <section
-      className={`relative grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 ${
+      className={`relative grid gap-3 ${GRID_COLUMNS[thumbnailSize]} ${
         isFetching ? 'opacity-60' : ''
       }`}
     >

--- a/components/search/search-page.tsx
+++ b/components/search/search-page.tsx
@@ -10,6 +10,8 @@ import { ActiveFacetTags } from '@/components/filters/active-facet-tags';
 import { ResultTypeToggle } from '@/components/search/result-type-toggle';
 import { SearchActionsMenu } from '@/components/search/search-actions-menu';
 import { ViewSwitcher } from '@/components/search/view-switcher';
+import { ThumbnailSizeControl } from '@/components/search/thumbnail-size-control';
+import { useThumbnailSize } from '@/hooks/search/use-thumbnail-size';
 import { SearchKeywordBar } from '@/components/search/search-keyword-bar';
 import { type ResultType } from '@/lib/search-types';
 import { resolveResultTypeLabel } from '@/lib/search-label-helpers';
@@ -46,6 +48,7 @@ type ResultListItem = ResultMap[ResultType];
 export function SearchPage({ resultType: initialType }: { resultType?: ResultType } = {}) {
   const t = useTranslations('search');
   const s = useSearchPageState(initialType);
+  const [thumbnailSize, setThumbnailSize] = useThumbnailSize();
   const { getLabel } = useModelLabels();
   const typeLabel = resolveResultTypeLabel(s.resultType, getLabel);
 
@@ -100,6 +103,13 @@ export function SearchPage({ resultType: initialType }: { resultType?: ResultTyp
               distributionEnabled={s.distributionEnabled}
               className="hidden sm:inline-flex"
             />
+            {s.viewMode === 'grid' && (
+              <ThumbnailSizeControl
+                size={thumbnailSize}
+                onChange={setThumbnailSize}
+                className="hidden sm:inline-flex"
+              />
+            )}
             <Button
               type="button"
               variant="ghost"
@@ -383,6 +393,7 @@ export function SearchPage({ resultType: initialType }: { resultType?: ResultTyp
                     resultType={s.resultType}
                     highlightKeyword={s.submittedKeyword}
                     isFetching={s.isFetching}
+                    thumbnailSize={thumbnailSize}
                   />
                 )
               ) : s.data.count > 0 && s.queryState.offset >= s.data.count ? (

--- a/components/search/search-page.tsx
+++ b/components/search/search-page.tsx
@@ -103,13 +103,6 @@ export function SearchPage({ resultType: initialType }: { resultType?: ResultTyp
               distributionEnabled={s.distributionEnabled}
               className="hidden sm:inline-flex"
             />
-            {s.viewMode === 'grid' && (
-              <ThumbnailSizeControl
-                size={thumbnailSize}
-                onChange={setThumbnailSize}
-                className="hidden sm:inline-flex"
-              />
-            )}
             <Button
               type="button"
               variant="ghost"
@@ -224,14 +217,24 @@ export function SearchPage({ resultType: initialType }: { resultType?: ResultTyp
             />
           </div>
         </div>
-        {/* Row 2: the result-type tabs */}
-        <div className="min-w-0">
-          <ResultTypeToggle
-            selectedType={s.resultType}
-            onChange={s.handleResultTypeChange}
-            enabledTypes={s.enabledCategories}
-            counts={s.countsByType}
-          />
+        {/* Row 2: the result-type tabs, with the grid thumbnail-size control
+            right-aligned on the same line (grid view only). */}
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <ResultTypeToggle
+              selectedType={s.resultType}
+              onChange={s.handleResultTypeChange}
+              enabledTypes={s.enabledCategories}
+              counts={s.countsByType}
+            />
+          </div>
+          {s.viewMode === 'grid' && (
+            <ThumbnailSizeControl
+              size={thumbnailSize}
+              onChange={setThumbnailSize}
+              className="hidden shrink-0 sm:inline-flex"
+            />
+          )}
         </div>
       </header>
 

--- a/components/search/thumbnail-size-control.test.tsx
+++ b/components/search/thumbnail-size-control.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ThumbnailSizeControl } from './thumbnail-size-control';
+
+describe('ThumbnailSizeControl', () => {
+  it('renders S/M/L options and marks the active one', () => {
+    render(<ThumbnailSizeControl size="small" onChange={vi.fn()} />);
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios.map((r) => r.textContent)).toEqual(['S', 'M', 'L']);
+
+    const small = screen.getByRole('radio', { name: 'Small thumbnails' });
+    expect(small.getAttribute('aria-checked')).toBe('true');
+    expect(
+      screen.getByRole('radio', { name: 'Medium thumbnails' }).getAttribute('aria-checked')
+    ).toBe('false');
+  });
+
+  it('reports the chosen size on click', () => {
+    const onChange = vi.fn();
+    render(<ThumbnailSizeControl size="medium" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Large thumbnails' }));
+    expect(onChange).toHaveBeenCalledWith('large');
+  });
+});

--- a/components/search/thumbnail-size-control.tsx
+++ b/components/search/thumbnail-size-control.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type ThumbnailSize = 'small' | 'medium' | 'large';
+
+const OPTIONS: { value: ThumbnailSize; label: string; title: string }[] = [
+  { value: 'small', label: 'S', title: 'Small thumbnails' },
+  { value: 'medium', label: 'M', title: 'Medium thumbnails' },
+  { value: 'large', label: 'L', title: 'Large thumbnails' },
+];
+
+// S/M/L segmented control for the search results grid — mirrors the
+// annotation gallery's DensityControl so the two feel like the same affordance.
+export function ThumbnailSizeControl({
+  size,
+  onChange,
+  className,
+}: {
+  size: ThumbnailSize;
+  onChange: (value: ThumbnailSize) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Thumbnail size"
+      className={cn('inline-flex overflow-hidden rounded-md border', className)}
+    >
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          role="radio"
+          aria-checked={size === opt.value}
+          aria-label={opt.title}
+          title={opt.title}
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            'border-l px-2.5 py-1.5 text-xs font-medium transition first:border-l-0',
+            size === opt.value
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/hooks/search/use-thumbnail-size.ts
+++ b/hooks/search/use-thumbnail-size.ts
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import type { ThumbnailSize } from '@/components/search/thumbnail-size-control';
+
+const STORAGE_KEY = 'search-grid-thumbnail-size';
+
+function isThumbnailSize(value: string | null): value is ThumbnailSize {
+  return value === 'small' || value === 'medium' || value === 'large';
+}
+
+// Grid-thumbnail size preference, persisted across sessions. Defaults to
+// 'medium' (the historical grid density) and is hydrated from localStorage in
+// an effect to keep SSR output stable.
+export function useThumbnailSize(): [ThumbnailSize, (value: ThumbnailSize) => void] {
+  const [size, setSize] = React.useState<ThumbnailSize>('medium');
+
+  React.useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- seed locally-owned state from localStorage after mount; deferring to an effect (vs. a lazy useState initializer) is required to avoid an SSR/client hydration mismatch, since `window` is unavailable during server render.
+    if (isThumbnailSize(saved)) setSize(saved);
+  }, []);
+
+  const change = React.useCallback((next: ThumbnailSize) => {
+    setSize(next);
+    window.localStorage.setItem(STORAGE_KEY, next);
+  }, []);
+
+  return [size, change];
+}


### PR DESCRIPTION
## What

Adds an **S / M / L** segmented control to the search **results grid** so users can shrink or grow the thumbnails. Fixes graph thumbnails reading as "much too big" — the reporter suggested reusing the S/M/L buttons from the Annotations page, which is the pattern adopted here.

Closes #72

## Changes

- **`components/search/thumbnail-size-control.tsx`** — new `ThumbnailSizeControl` (a `radiogroup` of S/M/L buttons), mirroring the annotation gallery's `DensityControl`.
- **`hooks/search/use-thumbnail-size.ts`** — `useThumbnailSize`, a localStorage-persisted (`search-grid-thumbnail-size`) preference; defaults to `medium` (the historical grid density) and hydrates in an effect to keep SSR output stable.
- **`components/search/search-grid.tsx`** — accepts a `thumbnailSize` prop mapping to different `grid-cols-*` column densities (small → more/smaller cells, large → fewer/bigger cells). `medium` reproduces the previous grid exactly.
- **`components/search/search-page.tsx`** — renders the control on the **result-type tabs row (Row 2), right-aligned** on the same line as the Manuscripts/Images/Graphs tabs. Grid-view only, hidden below the `sm` breakpoint. The tab strip keeps its `flex-1 min-w-0` scroll behaviour; the control is `shrink-0`.

## Notes

- Applies to every grid result type (graphs, images, manuscripts) since they share `SearchGrid`; the graph case is the one reported. The graph **table** view already uses fixed 80×80 thumbnails, so no change was needed there.
- `medium` is the default, so existing behaviour is unchanged until a user picks a size.
- This branch was descoped: unrelated containerized-dev / dependency commits that briefly shared the branch now live in #94.

## Testing

- Unit test for `ThumbnailSizeControl` (renders S/M/L, marks the active option, reports selection).
- `pnpm test`, `pnpm lint`, `pnpm format`, and `tsc --noEmit` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
