### PR TITLE
fix(i18n): add the missing `errors` message namespace (fixes MISSING_MESSAGE in error/404 boundaries)

### DIFF
--- a/lib/i18n-messages.test.ts
+++ b/lib/i18n-messages.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { defaultLocale, locales } from '@/lib/locale';
+
+const messagesDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'messages');
+
+type Messages = Record<string, unknown>;
+
+function loadLocale(locale: string): Messages {
+  return JSON.parse(readFileSync(join(messagesDir, `${locale}.json`), 'utf8')) as Messages;
+}
+
+/** Every leaf (dotted) key path in a message catalogue, e.g. `errors.backToHome`. */
+function leafKeyPaths(obj: Messages, prefix = ''): string[] {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return value !== null && typeof value === 'object'
+      ? leafKeyPaths(value as Messages, path)
+      : [path];
+  });
+}
+
+describe('i18n message catalogues', () => {
+  const reference = loadLocale(defaultLocale);
+  const referenceKeys = leafKeyPaths(reference).sort();
+
+  // Guards the class of bug where a namespace/key exists in one locale but not
+  // another (or is dropped entirely) — which throws MISSING_MESSAGE at render.
+  it.each(locales.filter((l) => l !== defaultLocale))(
+    'locale "%s" has the same key structure as the default locale',
+    (locale) => {
+      expect(leafKeyPaths(loadLocale(locale)).sort()).toEqual(referenceKeys);
+    }
+  );
+
+  // The error boundaries (app/error.tsx, app/not-found.tsx,
+  // components/page/entity-error-state.tsx) resolve these under `errors`.
+  const REQUIRED_ERROR_KEYS = [
+    'somethingWentWrong',
+    'unexpectedErrorTryAgain',
+    'backToHome',
+    'notFoundTitle',
+    'notFoundBody',
+  ] as const;
+
+  it.each(locales)(
+    'locale "%s" defines the errors namespace the error boundaries use',
+    (locale) => {
+      const errors = loadLocale(locale).errors as Record<string, string> | undefined;
+      expect(errors).toBeDefined();
+      for (const key of REQUIRED_ERROR_KEYS) {
+        expect(errors).toHaveProperty(key);
+        expect(typeof errors?.[key]).toBe('string');
+      }
+    }
+  );
+});

--- a/messages/en.json
+++ b/messages/en.json
@@ -35,6 +35,13 @@
     "signIn": "Sign in",
     "signOut": "Sign out"
   },
+  "errors": {
+    "somethingWentWrong": "Something went wrong",
+    "unexpectedErrorTryAgain": "An unexpected error occurred. Please try again.",
+    "backToHome": "Back to home",
+    "notFoundTitle": "Page not found",
+    "notFoundBody": "The page you're looking for doesn't exist or has moved."
+  },
   "nav": {
     "home": "Home",
     "search": "Search",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -35,6 +35,13 @@
     "signIn": "Se connecter",
     "signOut": "Se déconnecter"
   },
+  "errors": {
+    "somethingWentWrong": "Une erreur est survenue",
+    "unexpectedErrorTryAgain": "Une erreur inattendue s'est produite. Veuillez réessayer.",
+    "backToHome": "Retour à l'accueil",
+    "notFoundTitle": "Page introuvable",
+    "notFoundBody": "La page que vous recherchez n'existe pas ou a été déplacée."
+  },
   "nav": {
     "home": "Accueil",
     "search": "Rechercher",


### PR DESCRIPTION
## Bug

The error boundaries call `useTranslations('errors')`, but the `errors` namespace was **missing from both** `messages/en.json` and `messages/fr.json`:

- `app/error.tsx` → `errors.somethingWentWrong`, `errors.unexpectedErrorTryAgain`, `errors.backToHome`
- `app/not-found.tsx` → `errors.notFoundTitle`, `errors.notFoundBody`, `errors.backToHome`
- `components/page/entity-error-state.tsx` (used by the manuscript/hand route error boundaries) → `errors.somethingWentWrong`

So any error or 404 boundary threw `MISSING_MESSAGE: Could not resolve 'errors' in messages for locale 'en'` and rendered raw fallback instead of the intended UI. (Found while running the app in a container during unrelated dev-infra work.)

## Fix

- Add the `errors` namespace to **both** locales with the five keys the boundaries use. The `common.*` keys they also reference (`tryAgain`, `search`) already existed.
- Add `lib/i18n-messages.test.ts`, a catalogue regression test that:
  1. asserts **every configured locale has the same key structure** as the default locale (catches asymmetric missing keys), and
  2. **requires the `errors` namespace** the boundaries depend on (catches a symmetric omission like this one).

There was no message-parity test before, which is why this slipped through.

## Testing
- New test fails with the namespace removed, passes with it added (verified both ways).
- `pnpm test` → **671 passed**, plus `tsc`, `eslint`, `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)