### PR TITLE
fix(search): remove duplicate scribes "Period" column

### DIFF
--- a/components/search/results-table.tsx
+++ b/components/search/results-table.tsx
@@ -230,7 +230,6 @@ export const COLUMNS = {
     makeColumn('Scribe Name', (s: ScribeListItem) => s.name, 'name_exact'),
     makeColumn('Date', (s: ScribeListItem) => s.period),
     makeColumn('Scriptorium', (s: ScribeListItem) => s.scriptorium, 'scriptorium_exact'),
-    makeColumn('Period', (s: ScribeListItem) => s.period ?? '—'),
   ],
 
   hands: [

--- a/lib/search-export.ts
+++ b/lib/search-export.ts
@@ -30,7 +30,6 @@ export const COLUMN_FIELD_MAP: Record<ResultType, Record<string, string>> = {
     'Scribe Name': 'name',
     Date: 'period',
     Scriptorium: 'scriptorium',
-    Period: 'period',
   },
   hands: {
     'Hand Title': 'name',


### PR DESCRIPTION
## Problem

The **scribes** search results table defined two columns, **Date** and **Period**, that render the *same* value:

```ts
makeColumn('Date',   (s: ScribeListItem) => s.period),
makeColumn('Period', (s: ScribeListItem) => s.period ?? '—'),   // ← duplicate
```

The `COLUMN_FIELD_MAP` for CSV/JSON export aliased both headers to `period` as well. This is the same defect family as #70 (a column that doesn't carry a distinct value) — found while fixing that issue.

There is genuinely only one underlying field: the `Scribe` model has a single `period` FK (`common.Date`) and no separate date — the search document emits only `id, name, period, scriptorium`.

## Fix

Remove the redundant opt-in **Period** column and its export-map alias. **Date** is the default column and matches the `Date`-family labels used by every other result type (manuscripts "Text Date", texts "MS Date", graphs "Document Date", hands "Date"), so:

- **No change to the default scribes view** (`defaultVisibleColumns` was already `['Scribe Name', 'Date', 'Scriptorium']` — `Period` was opt-in only).
- The `search-export` guard added in the #70 work (every export header must map to a real column) stays satisfied.

## Scope note

The **backoffice** scribes list page has its own separate `Period` column (`scribes.colPeriod` i18n key, `app/backoffice/scribes/page.tsx`). That is a different table and is **not** touched.

## Alternative (maintainer's call)

If you'd rather the public column read **"Period"** than **"Date"** (it's arguably the more accurate term for a scribe's active era, and matches the backoffice), the swap is trivial — say the word and I'll flip the kept column's header + the default config instead. I went with "Date" purely for house-style consistency and a zero-diff default view.

## Verification

Run host-native in an isolated worktree off `main`:
- `vitest run` — **1090 passed** (106 files)
- `eslint` + `prettier --check` on both changed files — clean
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)