### PR TITLE
feat(backoffice): add user impersonation UI for admins

### DIFF
--- a/app/backoffice/users/page.test.tsx
+++ b/app/backoffice/users/page.test.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { PaginatedResponse, UserListItem } from '@/types/backoffice';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+
+const startImpersonation = vi.fn();
+let mockAuthUser: { id: number; username: string } | null = { id: 1, username: 'admin' };
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => ({
+    token: 'admin-token',
+    user: mockAuthUser,
+    startImpersonation,
+  }),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const getUsers = vi.fn();
+const createUser = vi.fn();
+const updateUser = vi.fn();
+const deleteUser = vi.fn();
+const impersonateUser = vi.fn();
+vi.mock('@/services/backoffice/users', () => ({
+  getUsers: (...args: unknown[]) => getUsers(...args),
+  createUser: (...args: unknown[]) => createUser(...args),
+  updateUser: (...args: unknown[]) => updateUser(...args),
+  deleteUser: (...args: unknown[]) => deleteUser(...args),
+  impersonateUser: (...args: unknown[]) => impersonateUser(...args),
+}));
+
+import { toast } from 'sonner';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import UsersPage from './page';
+
+function baseUser(overrides: Partial<UserListItem>): UserListItem {
+  return {
+    id: 0,
+    username: '',
+    email: '',
+    first_name: '',
+    last_name: '',
+    is_staff: false,
+    is_superuser: false,
+    is_active: true,
+    date_joined: '2024-01-01T00:00:00Z',
+    last_login: null,
+    ...overrides,
+  };
+}
+
+const ADMIN = baseUser({ id: 1, username: 'admin' });
+const STAFF = baseUser({ id: 2, username: 'staffer', is_staff: true });
+const SUPERUSER = baseUser({ id: 3, username: 'superadmin', is_superuser: true });
+const REGULAR = baseUser({ id: 4, username: 'regular' });
+
+function usersResponse(results: UserListItem[]): PaginatedResponse<UserListItem> {
+  return { count: results.length, next: null, previous: null, results };
+}
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <UsersPage />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+function rowFor(username: string): HTMLElement {
+  return screen.getByText(username).closest('tr') as HTMLElement;
+}
+
+beforeEach(() => {
+  push.mockClear();
+  startImpersonation.mockClear();
+  vi.mocked(toast.success).mockClear();
+  vi.mocked(toast.error).mockClear();
+  getUsers.mockReset();
+  createUser.mockReset();
+  updateUser.mockReset();
+  deleteUser.mockReset();
+  impersonateUser.mockReset();
+  mockAuthUser = { id: 1, username: 'admin' };
+  getUsers.mockResolvedValue(usersResponse([ADMIN, STAFF, SUPERUSER, REGULAR]));
+});
+
+describe('UsersPage impersonation action', () => {
+  it("disables the impersonate button for the signed-in admin's own row", async () => {
+    renderPage();
+    await screen.findByText('admin');
+
+    const button = within(rowFor('admin')).getByLabelText(/impersonate user/i);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables the impersonate button for staff rows', async () => {
+    renderPage();
+    await screen.findByText('staffer');
+
+    const button = within(rowFor('staffer')).getByLabelText(/impersonate user/i);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables the impersonate button for superuser rows', async () => {
+    renderPage();
+    await screen.findByText('superadmin');
+
+    const button = within(rowFor('superadmin')).getByLabelText(/impersonate user/i);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('enables the impersonate button for a regular, non-staff, non-self row', async () => {
+    renderPage();
+    await screen.findByText('regular');
+
+    const button = within(rowFor('regular')).getByLabelText(/impersonate user/i);
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('opens a confirmation dialog naming the target user when clicked', async () => {
+    renderPage();
+    await screen.findByText('regular');
+
+    fireEvent.click(within(rowFor('regular')).getByLabelText(/impersonate user/i));
+
+    expect(await screen.findByText(/impersonate "regular"/i)).toBeTruthy();
+  });
+
+  it('on confirm, calls impersonateUser, then startImpersonation + navigates home on success', async () => {
+    impersonateUser.mockResolvedValue({ auth_token: 'target-token' });
+    renderPage();
+    await screen.findByText('regular');
+
+    fireEvent.click(within(rowFor('regular')).getByLabelText(/impersonate user/i));
+    await screen.findByText(/impersonate "regular"/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /^impersonate$/i }));
+
+    await waitFor(() => expect(impersonateUser).toHaveBeenCalledWith('admin-token', 4));
+    await waitFor(() => expect(startImpersonation).toHaveBeenCalledWith('target-token'));
+    expect(push).toHaveBeenCalledWith('/');
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('shows an error toast and does not impersonate on failure', async () => {
+    impersonateUser.mockRejectedValue(new Error('boom'));
+    renderPage();
+    await screen.findByText('regular');
+
+    fireEvent.click(within(rowFor('regular')).getByLabelText(/impersonate user/i));
+    await screen.findByText(/impersonate "regular"/i);
+
+    fireEvent.click(screen.getByRole('button', { name: /^impersonate$/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(startImpersonation).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/app/backoffice/users/page.tsx
+++ b/app/backoffice/users/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/auth-context';
 import {
@@ -12,6 +13,7 @@ import {
   Plus,
   Pencil,
   Trash2,
+  VenetianMask,
   Eye,
   EyeOff,
   CheckCircle,
@@ -50,7 +52,13 @@ import {
   BackofficeErrorState,
   BackofficeLoadingState,
 } from '@/components/backoffice/common/query-state';
-import { getUsers, createUser, updateUser, deleteUser } from '@/services/backoffice/users';
+import {
+  getUsers,
+  createUser,
+  updateUser,
+  deleteUser,
+  impersonateUser,
+} from '@/services/backoffice/users';
 import { backofficeKeys } from '@/lib/backoffice/query-keys';
 import { formatApiError } from '@/lib/backoffice/format-api-error';
 import { runBulkAction } from '@/lib/backoffice/bulk-action';
@@ -68,6 +76,13 @@ function getInitials(user: UserListItem): string {
 
 function fullName(user: UserListItem): string {
   return [user.first_name, user.last_name].filter(Boolean).join(' ');
+}
+
+// Mirrors the backend's own restrictions (apps.users.services.impersonate_user):
+// never yourself, never a staff/superuser account. No point offering an action
+// that is guaranteed to 400/403.
+function canImpersonate(row: UserListItem, currentUserId: number | undefined): boolean {
+  return row.id !== currentUserId && !row.is_staff && !row.is_superuser;
 }
 
 function relativeTime(dateStr: string | null, t: (key: string) => string): string {
@@ -181,13 +196,15 @@ function SortHeader({
 
 export default function UsersPage() {
   const t = useTranslations('backoffice');
-  const { token } = useAuth();
+  const { token, user, startImpersonation } = useAuth();
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   // Dialog / mutation targets
   const [createOpen, setCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<UserListItem | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<UserListItem | null>(null);
+  const [impersonateTarget, setImpersonateTarget] = useState<UserListItem | null>(null);
   const [bulkDeleteIds, setBulkDeleteIds] = useState<string[]>([]);
 
   const [createForm, setCreateForm] = useState<UserCreatePayload>({ ...emptyCreate });
@@ -364,6 +381,19 @@ export default function UsersPage() {
     },
     onError: (err) => {
       toast.error(t('users.toastFailedDelete'), { description: formatApiError(err) });
+    },
+  });
+
+  const impersonateMut = useMutation({
+    mutationFn: (target: UserListItem) => impersonateUser(token!, target.id),
+    onSuccess: (data, target) => {
+      startImpersonation(data.auth_token);
+      toast.success(t('users.toastImpersonating', { username: target.username }));
+      setImpersonateTarget(null);
+      router.push('/');
+    },
+    onError: (err) => {
+      toast.error(t('users.toastFailedImpersonate'), { description: formatApiError(err) });
     },
   });
 
@@ -727,6 +757,34 @@ export default function UsersPage() {
                       </TableCell>
                       <TableCell>
                         <div className="flex items-center gap-1">
+                          {(() => {
+                            const impersonable = canImpersonate(u, user?.id);
+                            const reasonKey =
+                              u.id === user?.id
+                                ? 'users.tooltipImpersonateSelf'
+                                : 'users.tooltipImpersonateProtected';
+                            return (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-7 w-7 text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+                                      disabled={!impersonable}
+                                      aria-label={t('users.tooltipImpersonateUser')}
+                                      onClick={() => setImpersonateTarget(u)}
+                                    >
+                                      <VenetianMask className="h-3.5 w-3.5" />
+                                    </Button>
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  {impersonable ? t('users.tooltipImpersonateUser') : t(reasonKey)}
+                                </TooltipContent>
+                              </Tooltip>
+                            );
+                          })()}
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <Button
@@ -1091,6 +1149,18 @@ export default function UsersPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* ── Impersonate confirmation ────────────────────────────────── */}
+      <ConfirmDialog
+        open={!!impersonateTarget}
+        onOpenChange={(open) => !open && setImpersonateTarget(null)}
+        title={t('users.impersonateDialogTitle', { username: impersonateTarget?.username ?? '' })}
+        description={t('users.impersonateDialogDesc')}
+        confirmLabel={t('users.impersonateDialogConfirm')}
+        variant="default"
+        loading={impersonateMut.isPending}
+        onConfirm={() => impersonateTarget && impersonateMut.mutate(impersonateTarget)}
+      />
 
       {/* ── Single delete confirmation ──────────────────────────────── */}
       <ConfirmDialog

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import './globals.css';
 import { AuthProvider } from '@/contexts/auth-context';
+import { ImpersonationBanner } from '@/components/impersonation-banner';
 import { CollectionProvider } from '@/contexts/collection-context';
 import { SearchProvider } from '@/contexts/search-context';
 import { SiteFeaturesProvider } from '@/contexts/site-features-context';
@@ -95,6 +96,7 @@ export default async function RootLayout({
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AuthProvider>
+            <ImpersonationBanner />
             <SiteFeaturesProvider initialConfig={siteFeaturesConfig}>
               <ModelLabelsProvider initialConfig={modelLabelsConfig}>
                 <AppQueryProvider>

--- a/components/impersonation-banner.test.tsx
+++ b/components/impersonation-banner.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const push = vi.fn();
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push, refresh }) }));
+
+const stopImpersonation = vi.fn();
+let mockAuth: {
+  isImpersonating: boolean;
+  user: { username: string } | null;
+  stopImpersonation: () => void;
+};
+vi.mock('@/contexts/auth-context', () => ({
+  useAuth: () => mockAuth,
+}));
+
+import { ImpersonationBanner } from './impersonation-banner';
+
+beforeEach(() => {
+  push.mockClear();
+  refresh.mockClear();
+  stopImpersonation.mockClear();
+  mockAuth = { isImpersonating: false, user: null, stopImpersonation };
+});
+
+describe('ImpersonationBanner', () => {
+  it('renders nothing when not impersonating', () => {
+    mockAuth.isImpersonating = false;
+    const { container } = render(<ImpersonationBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the banner with the impersonated username when impersonating', () => {
+    mockAuth.isImpersonating = true;
+    mockAuth.user = { username: 'jdoe' };
+    render(<ImpersonationBanner />);
+    expect(screen.getByRole('alert').textContent).toContain('jdoe');
+    expect(screen.getByRole('button', { name: /stop impersonating/i })).not.toBeNull();
+  });
+
+  it('calls stopImpersonation and navigates home when the button is clicked', () => {
+    mockAuth.isImpersonating = true;
+    mockAuth.user = { username: 'jdoe' };
+    render(<ImpersonationBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: /stop impersonating/i }));
+
+    expect(stopImpersonation).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith('/');
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/impersonation-banner.tsx
+++ b/components/impersonation-banner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { VenetianMask } from 'lucide-react';
+import { useAuth } from '@/contexts/auth-context';
+import { Alert } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Persistent, app-wide banner shown while a superuser is browsing as another
+ * user (see `useAuth().isImpersonating`). Mounted in the root layout, inside
+ * `AuthProvider`, so it's visible on every route — impersonation targets are
+ * always regular (non-staff) accounts, so the natural post-impersonation
+ * landing place is the public site, not the backoffice.
+ */
+export function ImpersonationBanner() {
+  const { isImpersonating, user, stopImpersonation } = useAuth();
+  const router = useRouter();
+  const t = useTranslations('impersonation');
+
+  if (!isImpersonating) return null;
+
+  function handleStop() {
+    stopImpersonation();
+    router.push('/');
+    router.refresh();
+  }
+
+  return (
+    <Alert
+      variant="default"
+      className="fixed inset-x-0 top-0 z-[100] rounded-none border-x-0 border-t-0 border-amber-600 bg-amber-400 px-4 py-2.5 text-amber-950 shadow-md dark:border-amber-500 dark:bg-amber-600 dark:text-amber-50"
+    >
+      <div className="mx-auto flex max-w-screen-lg flex-wrap items-center justify-center gap-x-3 gap-y-1.5">
+        <VenetianMask className="h-4 w-4 shrink-0" aria-hidden="true" />
+        <span className="text-sm font-medium">
+          {t('bannerMessage', { username: user?.username ?? '' })}
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 border-amber-950/30 bg-transparent text-amber-950 hover:bg-amber-950/10 dark:border-amber-50/30 dark:text-amber-50 dark:hover:bg-amber-50/10"
+          onClick={handleStop}
+        >
+          {t('stopButton')}
+        </Button>
+      </div>
+    </Alert>
+  );
+}

--- a/contexts/auth-context.test.tsx
+++ b/contexts/auth-context.test.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+
+const getUserProfile = vi.fn();
+const logoutUser = vi.fn();
+vi.mock('@/utils/api', () => ({
+  getUserProfile: (...args: unknown[]) => getUserProfile(...args),
+  logoutUser: (...args: unknown[]) => logoutUser(...args),
+}));
+
+import { AuthProvider, useAuth } from './auth-context';
+import {
+  clearAuthTokenCookie,
+  clearImpersonatorTokenCookie,
+  getAuthTokenCookie,
+  getImpersonatorTokenCookie,
+  setAuthTokenCookie,
+  setImpersonatorTokenCookie,
+} from '@/lib/auth-token-cookie';
+import type { UserProfile } from '@/types';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+function fakeProfile(username: string): UserProfile {
+  return {
+    id: 1,
+    email: `${username}@example.com`,
+    username,
+    first_name: '',
+    last_name: '',
+    is_staff: false,
+    is_superuser: false,
+  };
+}
+
+beforeEach(() => {
+  push.mockClear();
+  getUserProfile.mockReset();
+  logoutUser.mockReset();
+  logoutUser.mockResolvedValue(undefined);
+  clearAuthTokenCookie();
+  clearImpersonatorTokenCookie();
+});
+
+afterEach(() => {
+  clearAuthTokenCookie();
+  clearImpersonatorTokenCookie();
+});
+
+describe('AuthProvider impersonation', () => {
+  it('startImpersonation stashes the current token and switches to the new one', async () => {
+    getUserProfile.mockImplementation(async (token: string) => fakeProfile(`user-${token}`));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    act(() => result.current.setToken('admin-token'));
+    await waitFor(() => expect(result.current.token).toBe('admin-token'));
+
+    act(() => result.current.startImpersonation('target-token'));
+
+    await waitFor(() => expect(result.current.token).toBe('target-token'));
+    expect(result.current.isImpersonating).toBe(true);
+    expect(getImpersonatorTokenCookie()).toBe('admin-token');
+    expect(getAuthTokenCookie()).toBe('target-token');
+  });
+
+  it('a second startImpersonation call does not clobber the original stashed token', async () => {
+    getUserProfile.mockImplementation(async (token: string) => fakeProfile(`user-${token}`));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    act(() => result.current.setToken('admin-token'));
+    await waitFor(() => expect(result.current.token).toBe('admin-token'));
+
+    act(() => result.current.startImpersonation('target-token-1'));
+    await waitFor(() => expect(result.current.token).toBe('target-token-1'));
+
+    // Nested impersonation: switching again while already impersonating must
+    // NOT overwrite the stashed original admin token.
+    act(() => result.current.startImpersonation('target-token-2'));
+    await waitFor(() => expect(result.current.token).toBe('target-token-2'));
+
+    expect(result.current.isImpersonating).toBe(true);
+    expect(getImpersonatorTokenCookie()).toBe('admin-token');
+  });
+
+  it('stopImpersonation restores the stashed token and clears the stash', async () => {
+    getUserProfile.mockImplementation(async (token: string) => fakeProfile(`user-${token}`));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    act(() => result.current.setToken('admin-token'));
+    await waitFor(() => expect(result.current.token).toBe('admin-token'));
+
+    act(() => result.current.startImpersonation('target-token'));
+    await waitFor(() => expect(result.current.token).toBe('target-token'));
+
+    act(() => result.current.stopImpersonation());
+
+    await waitFor(() => expect(result.current.token).toBe('admin-token'));
+    expect(result.current.isImpersonating).toBe(false);
+    expect(getImpersonatorTokenCookie()).toBeNull();
+  });
+
+  it('restores isImpersonating on initial mount when an impersonator cookie is already present', async () => {
+    setAuthTokenCookie('target-token');
+    setImpersonatorTokenCookie('admin-token');
+    getUserProfile.mockImplementation(async (token: string) => fakeProfile(`user-${token}`));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isImpersonating).toBe(true);
+    expect(result.current.token).toBe('target-token');
+  });
+
+  it('does not report isImpersonating on a normal (non-impersonated) mount', async () => {
+    setAuthTokenCookie('admin-token');
+    getUserProfile.mockImplementation(async (token: string) => fakeProfile(`user-${token}`));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isImpersonating).toBe(false);
+  });
+
+  it('logout clears the stashed impersonator token', async () => {
+    getUserProfile.mockImplementation(async (token: string) => fakeProfile(`user-${token}`));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+
+    act(() => result.current.setToken('admin-token'));
+    await waitFor(() => expect(result.current.token).toBe('admin-token'));
+
+    act(() => result.current.startImpersonation('target-token'));
+    await waitFor(() => expect(result.current.token).toBe('target-token'));
+
+    act(() => result.current.logout());
+
+    await waitFor(() => expect(result.current.token).toBeNull());
+    expect(result.current.isImpersonating).toBe(false);
+    expect(getImpersonatorTokenCookie()).toBeNull();
+    expect(push).toHaveBeenCalledWith('/login');
+  });
+});

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -5,8 +5,11 @@ import { useRouter } from 'next/navigation';
 import { getUserProfile, logoutUser } from '@/utils/api';
 import {
   clearAuthTokenCookie,
+  clearImpersonatorTokenCookie,
   getAuthTokenCookie,
+  getImpersonatorTokenCookie,
   setAuthTokenCookie,
+  setImpersonatorTokenCookie,
 } from '@/lib/auth-token-cookie';
 import type { UserProfile } from '@/types';
 
@@ -14,7 +17,10 @@ interface AuthContextType {
   token: string | null;
   user: UserProfile | null;
   isReady: boolean;
+  isImpersonating: boolean;
   setToken: (token: string | null) => void;
+  startImpersonation: (newToken: string) => void;
+  stopImpersonation: () => void;
   logout: () => void;
 }
 
@@ -24,6 +30,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<UserProfile | null>(null);
   const [isReady, setIsReady] = useState(false);
+  const [isImpersonating, setIsImpersonating] = useState(false);
   const router = useRouter();
 
   const setAuthToken = useCallback((nextToken: string | null) => {
@@ -37,6 +44,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     clearAuthTokenCookie();
   }, []);
 
+  const startImpersonation = useCallback(
+    (newToken: string) => {
+      // Only stash the current token if we're not already impersonating —
+      // otherwise a nested impersonation would clobber the real original
+      // admin token with an already-impersonated one, making it unrecoverable.
+      if (!isImpersonating && token) {
+        setImpersonatorTokenCookie(token);
+      }
+      setIsImpersonating(true);
+      setAuthToken(newToken);
+    },
+    [isImpersonating, token, setAuthToken]
+  );
+
+  const stopImpersonation = useCallback(() => {
+    const originalToken = getImpersonatorTokenCookie();
+    if (originalToken) {
+      setAuthToken(originalToken);
+      clearImpersonatorTokenCookie();
+    }
+    setIsImpersonating(false);
+  }, [setAuthToken]);
+
   const logout = useCallback(() => {
     // Revoke the server-side token so a captured token can't be reused after
     // logout. Fire-and-forget: a network/HTTP failure must not block the local
@@ -45,6 +75,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       void logoutUser(token).catch(() => {});
     }
     setAuthToken(null);
+    // Don't leave a stale stashed original token around if the user fully
+    // logs out while impersonating.
+    clearImpersonatorTokenCookie();
+    setIsImpersonating(false);
     setUser(null);
     setIsReady(true);
     router.push('/login');
@@ -52,6 +86,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const storedToken = getAuthTokenCookie();
+    const storedImpersonatorToken = getImpersonatorTokenCookie();
+    queueMicrotask(() => setIsImpersonating(!!storedImpersonatorToken));
 
     if (storedToken) {
       queueMicrotask(() => setAuthToken(storedToken));
@@ -97,8 +133,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [token, setAuthToken]);
 
   const value = useMemo<AuthContextType>(
-    () => ({ token, user, isReady, setToken: setAuthToken, logout }),
-    [token, user, isReady, setAuthToken, logout]
+    () => ({
+      token,
+      user,
+      isReady,
+      isImpersonating,
+      setToken: setAuthToken,
+      startImpersonation,
+      stopImpersonation,
+      logout,
+    }),
+    [
+      token,
+      user,
+      isReady,
+      isImpersonating,
+      setAuthToken,
+      startImpersonation,
+      stopImpersonation,
+      logout,
+    ]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/lib/auth-token-cookie.ts
+++ b/lib/auth-token-cookie.ts
@@ -1,6 +1,12 @@
 const AUTH_TOKEN_COOKIE_NAME = 'archetype_auth_token';
 const AUTH_TOKEN_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
 
+// Stashes the ORIGINAL admin's token while impersonating another user, so it
+// can be restored when impersonation ends. Same shape/lifetime as the main
+// auth token cookie.
+const IMPERSONATOR_TOKEN_COOKIE_NAME = 'archetype_impersonator_token';
+const IMPERSONATOR_TOKEN_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30; // 30 days
+
 function secureSuffix(): string {
   if (typeof window === 'undefined') {
     return '';
@@ -33,3 +39,31 @@ export function getAuthTokenCookie(): string | null {
 }
 
 export const AUTH_TOKEN_COOKIE = AUTH_TOKEN_COOKIE_NAME;
+
+export function setImpersonatorTokenCookie(token: string): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie =
+    `${IMPERSONATOR_TOKEN_COOKIE_NAME}=${encodeURIComponent(token)}; Path=/; Max-Age=${IMPERSONATOR_TOKEN_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax` +
+    secureSuffix();
+}
+
+export function clearImpersonatorTokenCookie(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = `${IMPERSONATOR_TOKEN_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax${secureSuffix()}`;
+}
+
+export function getImpersonatorTokenCookie(): string | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${IMPERSONATOR_TOKEN_COOKIE_NAME}=([^;]*)`)
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export const IMPERSONATOR_TOKEN_COOKIE = IMPERSONATOR_TOKEN_COOKIE_NAME;

--- a/messages/en.json
+++ b/messages/en.json
@@ -1837,6 +1837,9 @@
       "statusInactive": "Inactive",
       "tooltipEditUser": "Edit user",
       "tooltipDeleteUser": "Delete user",
+      "tooltipImpersonateUser": "Impersonate user",
+      "tooltipImpersonateSelf": "You cannot impersonate yourself",
+      "tooltipImpersonateProtected": "Staff and superuser accounts cannot be impersonated",
       "createDialogTitle": "New User",
       "createDialogDesc": "Set up a new account. The password will be securely hashed.",
       "editDialogMemberSince": "Member since {date}",
@@ -1872,12 +1875,17 @@
       "bulkDeleteTitle": "Delete {count} user(s)?",
       "bulkDeleteDesc": "This action cannot be undone. All selected users will be permanently removed.",
       "bulkDeleteConfirm": "Delete All",
+      "impersonateDialogTitle": "Impersonate \"{username}\"?",
+      "impersonateDialogDesc": "This action is audited. Your active session will switch to this user's account so you can browse the site as them. Use \"Stop impersonating\" to return to your own account.",
+      "impersonateDialogConfirm": "Impersonate",
       "toastUserCreated": "User created",
       "toastFailedCreate": "Failed to create user",
       "toastUserUpdated": "User updated",
       "toastFailedUpdate": "Failed to update user",
       "toastUserDeleted": "User deleted",
       "toastFailedDelete": "Failed to delete user",
+      "toastImpersonating": "Now browsing as {username}",
+      "toastFailedImpersonate": "Failed to impersonate user",
       "failedLoad": "Failed to load users",
       "relativeNever": "Never",
       "relativeJustNow": "Just now"
@@ -2550,6 +2558,10 @@
     "hidePassword": "Hide password",
     "showPassword": "Show password",
     "signingIn": "Signing in…"
+  },
+  "impersonation": {
+    "bannerMessage": "Viewing the site as {username}",
+    "stopButton": "Stop impersonating"
   },
   "hand": {
     "breadcrumb": "Hands",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1837,6 +1837,9 @@
       "statusInactive": "Inactif",
       "tooltipEditUser": "Modifier l'utilisateur",
       "tooltipDeleteUser": "Supprimer l'utilisateur",
+      "tooltipImpersonateUser": "Emprunter l'identité de l'utilisateur",
+      "tooltipImpersonateSelf": "Vous ne pouvez pas emprunter votre propre identité",
+      "tooltipImpersonateProtected": "Impossible d'emprunter l'identité d'un compte personnel ou superutilisateur",
       "createDialogTitle": "Nouvel utilisateur",
       "createDialogDesc": "Configurer un nouveau compte. Le mot de passe sera stocké de façon sécurisée (hashé).",
       "editDialogMemberSince": "Membre depuis {date}",
@@ -1872,12 +1875,17 @@
       "bulkDeleteTitle": "Supprimer {count} utilisateur(s) ?",
       "bulkDeleteDesc": "Cette action est irréversible. Tous les utilisateurs sélectionnés seront définitivement supprimés.",
       "bulkDeleteConfirm": "Tout supprimer",
+      "impersonateDialogTitle": "Emprunter l'identité de « {username} » ?",
+      "impersonateDialogDesc": "Cette action est journalisée (audit). Votre session active basculera vers le compte de cet utilisateur pour vous permettre de parcourir le site à sa place. Utilisez « Arrêter l'emprunt d'identité » pour revenir à votre propre compte.",
+      "impersonateDialogConfirm": "Emprunter l'identité",
       "toastUserCreated": "Utilisateur créé",
       "toastFailedCreate": "Échec de la création de l'utilisateur",
       "toastUserUpdated": "Utilisateur mis à jour",
       "toastFailedUpdate": "Échec de la mise à jour de l'utilisateur",
       "toastUserDeleted": "Utilisateur supprimé",
       "toastFailedDelete": "Échec de la suppression de l'utilisateur",
+      "toastImpersonating": "Vous naviguez maintenant en tant que {username}",
+      "toastFailedImpersonate": "Échec de l'emprunt d'identité",
       "failedLoad": "Échec du chargement des utilisateurs",
       "relativeNever": "Jamais",
       "relativeJustNow": "À l'instant"
@@ -2550,6 +2558,10 @@
     "hidePassword": "Masquer le mot de passe",
     "showPassword": "Afficher le mot de passe",
     "signingIn": "Connexion en cours…"
+  },
+  "impersonation": {
+    "bannerMessage": "Vous consultez le site en tant que {username}",
+    "stopButton": "Arrêter l'emprunt d'identité"
   },
   "hand": {
     "breadcrumb": "Mains",

--- a/services/backoffice/users.ts
+++ b/services/backoffice/users.ts
@@ -1,12 +1,26 @@
 import { createCrudService } from './crud-factory';
+import { backofficePost } from './api-client';
 import type { PaginatedResponse, UserListItem, UserDetail } from '@/types/backoffice';
 
-const usersCrud = createCrudService<PaginatedResponse<UserListItem>, UserDetail>(
-  '/api/v1/auth/management/users/'
-);
+const USERS_BASE_PATH = '/api/v1/auth/management/users/';
+
+const usersCrud = createCrudService<PaginatedResponse<UserListItem>, UserDetail>(USERS_BASE_PATH);
 
 export const getUsers = usersCrud.list;
 export const getUser = usersCrud.get;
 export const createUser = usersCrud.create;
 export const updateUser = usersCrud.update;
 export const deleteUser = usersCrud.remove;
+
+/**
+ * Support-style impersonation: mint (or reuse) the target user's own auth
+ * token so the caller can swap its stored bearer token and browse as them.
+ * Superuser-only; the backend 400s for self-impersonation and 403s for
+ * staff/superuser targets (see apps.users.services.impersonate_user).
+ */
+export function impersonateUser(
+  token: string,
+  id: UserListItem['id']
+): Promise<{ auth_token: string }> {
+  return backofficePost<{ auth_token: string }>(`${USERS_BASE_PATH}${id}/impersonate/`, token, {});
+}


### PR DESCRIPTION
## Summary
Cross-repo dependency: requires backend PR archetype-pal/backend#152 (`POST /api/v1/auth/management/users/{id}/impersonate/`, superuser-only, token-swap) to work end-to-end.

There was previously no frontend UI for impersonation at all. Adds:

- An "Impersonate" action on the backoffice users table (`app/backoffice/users/page.tsx`), disabled with an explanatory tooltip for the current user's own row and for staff/superuser targets (mirrors the backend's own restrictions), gated behind a confirmation dialog.
- `startImpersonation`/`stopImpersonation`/`isImpersonating` on the auth context (`contexts/auth-context.tsx`): stashes the admin's real token in a second cookie while impersonating, restores it on "stop".
- A site-wide `ImpersonationBanner` (mounted in the root layout, so it's visible on both the public site and backoffice — impersonation targets are always non-staff, so the session lands on the public site after switching) with a "Stop impersonating" button.
- `services/backoffice/users.ts`: `impersonateUser(token, id)`.

## Test plan
- [x] `vitest run` — full suite 117 files / 1171 tests passed (19 new)
- [x] `tsc --noEmit` clean
- [x] `eslint` / `prettier --check` clean
- [ ] Smoke test against the real backend once #152 is merged

No new dependencies.

---
Side note (unrelated, left untouched): noticed `messages/en.json`'s `login.signIn` key holds French text ("Se connecter") in the English catalogue — pre-existing, out of scope here.