### PR TITLE
fix(site-features): surface degraded reads instead of saving defaults over real config (review follow-up to #111)

### DIFF
--- a/app/api/app-settings/route.test.ts
+++ b/app/api/app-settings/route.test.ts
@@ -12,8 +12,9 @@ const { apiFetch, authFetch } = vi.hoisted(() => ({
 
 vi.mock('@/lib/api-fetch', () => ({ apiFetch, authFetch }));
 
+import { revalidateTag } from 'next/cache';
 import type { NextRequest } from 'next/server';
-import { PUT } from './route';
+import { GET, PUT } from './route';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -147,6 +148,29 @@ describe('PUT /api/app-settings — the superuser gate protecting the flags', ()
     );
     expect(res.status).toBe(403);
     expect((await readSiteFeatures()).features).toEqual(before.features);
+  });
+});
+
+describe('a degraded read is never passed off as the stored config', () => {
+  beforeEach(() => {
+    apiFetch.mockImplementation(async () => jsonResponse({ error: 'down' }, 503));
+  });
+
+  it('GET answers 503 instead of a 200 the editor would PUT straight back', async () => {
+    expect((await GET()).status).toBe(503);
+  });
+
+  it('PUT refuses rather than merging the payload over the fallback', async () => {
+    const response = await PUT(putRequest(getDefaultConfig()));
+    expect(response.status).toBe(503);
+    expect(authFetch.mock.calls.some(([path]) => path === '/api/v1/app-settings/')).toBe(false);
+  });
+});
+
+describe('PUT /api/app-settings — cache invalidation', () => {
+  it('purges the cached read rather than only marking it stale', async () => {
+    await PUT(putRequest(getDefaultConfig()));
+    expect(revalidateTag).toHaveBeenCalledWith('site-features', { expire: 0 });
   });
 });
 

--- a/app/api/app-settings/route.ts
+++ b/app/api/app-settings/route.ts
@@ -15,8 +15,13 @@ async function verifySuperuser(token: string): Promise<boolean> {
   }
 }
 
+/** 503 rather than a 200 full of defaults: the backoffice editor PUTs back
+ *  whatever it was handed, so a fallback served as healthy erases the config. */
 export async function GET() {
   const config = await readSiteFeatures();
+  if (config.degraded) {
+    return NextResponse.json({ error: 'Site features unavailable' }, { status: 503 });
+  }
   return NextResponse.json(config);
 }
 
@@ -50,6 +55,11 @@ export async function PUT(request: NextRequest) {
   // the full map still wins key-by-key.
   const payload = body as SiteFeaturesConfig;
   const current = await readSiteFeatures();
+  // The merge below is over `current`, so merging over a degraded read would
+  // re-enable flags nobody touched.
+  if (current.degraded) {
+    return NextResponse.json({ error: 'Site features unavailable' }, { status: 503 });
+  }
   let normalized: SiteFeaturesConfig;
   try {
     normalized = await writeSiteFeatures(
@@ -59,16 +69,13 @@ export async function PUT(request: NextRequest) {
       },
       token
     );
-  } catch {
+  } catch (err) {
+    console.error('[site-features] backend write failed', err);
     return NextResponse.json({ error: 'Failed to update site features' }, { status: 502 });
   }
-  // Invalidate the cached `readSiteFeatures()` fetch entry itself (the actual
-  // fix — see the doc comment on `SITE_FEATURES_TAG`) as well as the rendered
-  // layout, so an edit is visible immediately instead of waiting out the
-  // revalidation window. The second argument is a cache-life profile, not
-  // optional as of Next 16 — 'minutes' (revalidate: 60s) matches the
-  // `next.revalidate: 60` used when tagging the fetch in `readSiteFeatures`.
-  revalidateTag(SITE_FEATURES_TAG, 'minutes');
+  // `{ expire: 0 }` purges the cached fetch entry; a named cache-life profile
+  // would only mark it stale, and a stale entry still serves the old body.
+  revalidateTag(SITE_FEATURES_TAG, { expire: 0 });
   revalidatePath('/', 'layout');
   // Return the normalized config (with sectionOrder canonicalized) so the
   // client's cache reflects what's actually on disk.

--- a/app/backoffice/site-features/page.test.tsx
+++ b/app/backoffice/site-features/page.test.tsx
@@ -1,0 +1,49 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getDefaultConfig } from '@/lib/site-features';
+import SiteFeaturesPage from './page';
+
+vi.mock('@/contexts/auth-context', () => ({ useAuth: () => ({ token: 'tok' }) }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@/contexts/model-labels-context', () => ({
+  useModelLabels: () => ({ getLabel: (key: string) => key }),
+}));
+
+let getStatus: number;
+
+beforeEach(() => {
+  getStatus = 200;
+  vi.stubGlobal('fetch', async () =>
+    getStatus === 200
+      ? new Response(JSON.stringify(getDefaultConfig()), { status: 200 })
+      : new Response(JSON.stringify({ error: 'unavailable' }), { status: getStatus })
+  );
+});
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <SiteFeaturesPage />
+    </QueryClientProvider>
+  );
+}
+
+describe('<SiteFeaturesPage>', () => {
+  it('shows an error state instead of an editable form full of defaults', async () => {
+    getStatus = 503;
+    renderPage();
+
+    expect(await screen.findByText('Failed to load site features')).toBeTruthy();
+    expect(screen.queryByText('Site Sections')).toBeNull();
+  });
+
+  it('renders the form when the read succeeds', async () => {
+    renderPage();
+    expect(await screen.findByText('Site Sections')).toBeTruthy();
+  });
+});

--- a/app/backoffice/site-features/page.tsx
+++ b/app/backoffice/site-features/page.tsx
@@ -3,13 +3,17 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ToggleLeft, Loader2 } from 'lucide-react';
+import { ToggleLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslations } from 'next-intl';
 import { useAuth } from '@/contexts/auth-context';
 import { useUnsavedGuard } from '@/hooks/backoffice/use-unsaved-guard';
 import { useKeyboardShortcut } from '@/hooks/backoffice/use-keyboard-shortcut';
 import { UnsavedChangesBar } from '@/components/backoffice/common/unsaved-changes-bar';
+import {
+  BackofficeErrorState,
+  BackofficeLoadingState,
+} from '@/components/backoffice/common/query-state';
 import { SectionToggles } from '@/components/backoffice/site-features/section-toggles';
 import { FeatureToggles } from '@/components/backoffice/site-features/feature-toggles';
 import { SearchCategoryConfigPanel } from '@/components/backoffice/site-features/search-category-config';
@@ -55,7 +59,12 @@ export default function SiteFeaturesPage() {
   const t = useTranslations('backoffice');
   const defaults = getDefaultConfig();
 
-  const { data: serverConfig, isLoading } = useQuery({
+  const {
+    data: serverConfig,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
     queryKey: ['site-features'],
     queryFn: fetchSiteFeatures,
   });
@@ -131,13 +140,12 @@ export default function SiteFeaturesPage() {
     setDirty(true);
   };
 
-  if (isLoading) {
+  if (isLoading) return <BackofficeLoadingState />;
+  // Never render the form off `defaults` — saving it would erase the stored config.
+  if (isError)
     return (
-      <div className="flex items-center justify-center py-20">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
+      <BackofficeErrorState message={t('siteFeatures.failedLoad')} onRetry={() => refetch()} />
     );
-  }
 
   return (
     <div className="space-y-5 pb-16">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,12 +80,10 @@ export default async function RootLayout({
 }>) {
   const requestHeaders = await headers();
   const nonce = requestHeaders.get('x-nonce') ?? undefined;
-  const [siteFeaturesConfig, modelLabelsConfig, locale, messages] = await Promise.all([
-    readSiteFeatures(),
-    readModelLabels(),
-    getLocale(),
-    getMessages(),
-  ]);
+  // `degraded` is dropped here: it would otherwise be serialized into the RSC
+  // payload of the client provider below and advertise backend health publicly.
+  const [{ degraded: _degraded, ...siteFeaturesConfig }, modelLabelsConfig, locale, messages] =
+    await Promise.all([readSiteFeatures(), readModelLabels(), getLocale(), getMessages()]);
 
   return (
     <html lang={locale} suppressHydrationWarning>

--- a/config/site-features.test.ts
+++ b/config/site-features.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { SEARCH_RESULT_TYPES, getFacetOrder } from '@/lib/search-types';
+import { getDefaultConfig } from '@/lib/site-features';
 import { COLUMN_HEADERS_BY_TYPE } from '@/components/search/results-table';
 import siteFeatures from './site-features.json';
 
@@ -15,6 +16,12 @@ describe('site-features.json', () => {
     string,
     { visibleColumns: string[]; visibleFacets: string[] }
   >;
+
+  // A degraded read serves `getDefaultConfig()`, so its nav order has to be the
+  // seeded one or a backend blip silently reshuffles the public nav.
+  it('agrees with the hardcoded default section order', () => {
+    expect(getDefaultConfig().sectionOrder).toEqual(siteFeatures.sectionOrder);
+  });
 
   it('covers every search result type', () => {
     expect(Object.keys(categories).sort()).toEqual([...SEARCH_RESULT_TYPES].sort());

--- a/lib/site-features-server.test.ts
+++ b/lib/site-features-server.test.ts
@@ -9,9 +9,10 @@ const { apiFetch, authFetch } = vi.hoisted(() => ({
 
 vi.mock('./api-fetch', () => ({ apiFetch, authFetch }));
 
-// Imported after the mock so `readSiteFeatures`/`writeSiteFeatures` pick up
-// the mocked `apiFetch`/`authFetch` rather than issuing real network calls.
-const { readSiteFeatures, writeSiteFeatures } = await import('./site-features-server');
+// Re-imported per test (after the api-fetch mock, and after `vi.resetModules`)
+// so the module-scope last-known-good starts empty each time.
+let readSiteFeatures: typeof import('./site-features-server').readSiteFeatures;
+let writeSiteFeatures: typeof import('./site-features-server').writeSiteFeatures;
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -26,9 +27,11 @@ function legacyResponseBody() {
   return { sections, sectionOrder, searchCategories };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   apiFetch.mockReset();
   authFetch.mockReset();
+  vi.resetModules();
+  ({ readSiteFeatures, writeSiteFeatures } = await import('./site-features-server'));
 });
 
 afterEach(() => {
@@ -70,33 +73,32 @@ describe('readSiteFeatures', () => {
     expect(config.searchCategories).not.toBe(defaults.searchCategories);
   });
 
-  it('falls back to defaults when the response is not ok', async () => {
+  it('flags the fallback as degraded rather than passing it off as a real config', async () => {
+    const failures: unknown[] = [
+      jsonResponse({ error: 'nope' }, 500),
+      ...[null, [], 'oops', 7].map((junk) => jsonResponse(junk)),
+      { ok: true, json: () => Promise.reject(new Error('bad json')) },
+    ];
+    for (const failure of failures) {
+      apiFetch.mockResolvedValueOnce(failure as Response);
+      expect(await readSiteFeatures()).toEqual({ ...getDefaultConfig(), degraded: true });
+    }
+    apiFetch.mockRejectedValueOnce(new Error('network down'));
+    expect(await readSiteFeatures()).toEqual({ ...getDefaultConfig(), degraded: true });
+  });
+
+  it('serves the last successful config when a later read fails', async () => {
+    const stored = getDefaultConfig();
+    stored.sections.lightbox = false;
+    stored.features.manuscriptDescriptions = false;
+    apiFetch.mockResolvedValueOnce(jsonResponse(stored));
+    await readSiteFeatures();
+
     apiFetch.mockResolvedValueOnce(jsonResponse({ error: 'nope' }, 500));
     const config = await readSiteFeatures();
-    expect(config).toEqual(getDefaultConfig());
-  });
-
-  it('falls back to defaults when the fetch throws (network error)', async () => {
-    apiFetch.mockRejectedValueOnce(new Error('network down'));
-    const config = await readSiteFeatures();
-    expect(config).toEqual(getDefaultConfig());
-  });
-
-  it('falls back to defaults when the response body is not a plain object', async () => {
-    for (const junk of [null, [], 'oops', 7]) {
-      apiFetch.mockResolvedValueOnce(jsonResponse(junk));
-      const config = await readSiteFeatures();
-      expect(config).toEqual(getDefaultConfig());
-    }
-  });
-
-  it('falls back to defaults when response.json() throws (malformed JSON)', async () => {
-    apiFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.reject(new Error('bad json')),
-    } as unknown as Response);
-    const config = await readSiteFeatures();
-    expect(config).toEqual(getDefaultConfig());
+    expect(config.sections.lightbox).toBe(false);
+    expect(config.features.manuscriptDescriptions).toBe(false);
+    expect(config.degraded).toBe(true);
   });
 
   it('ignores unknown flag keys and non-boolean values from the backend', async () => {

--- a/lib/site-features-server.test.ts
+++ b/lib/site-features-server.test.ts
@@ -101,6 +101,16 @@ describe('readSiteFeatures', () => {
     expect(config.degraded).toBe(true);
   });
 
+  it('hands out copies, so a consumer mutation cannot corrupt the remembered config', async () => {
+    const stored = getDefaultConfig();
+    stored.sections.lightbox = false;
+    apiFetch.mockResolvedValueOnce(jsonResponse(stored));
+    (await readSiteFeatures()).sections.lightbox = true;
+
+    apiFetch.mockRejectedValueOnce(new Error('network down'));
+    expect((await readSiteFeatures()).sections.lightbox).toBe(false);
+  });
+
   it('ignores unknown flag keys and non-boolean values from the backend', async () => {
     apiFetch.mockResolvedValueOnce(
       jsonResponse({
@@ -141,6 +151,19 @@ describe('writeSiteFeatures', () => {
 
     const normalized = await writeSiteFeatures(config, 'staff-token');
     expect(normalized.features).toEqual({ manuscriptDescriptions: true });
+  });
+
+  it('becomes the last-known-good, so a read failing right after a save keeps it', async () => {
+    apiFetch.mockResolvedValueOnce(jsonResponse(getDefaultConfig()));
+    await readSiteFeatures();
+
+    const saved = getDefaultConfig();
+    saved.sections.lightbox = false;
+    authFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await writeSiteFeatures(saved, 'staff-token');
+
+    apiFetch.mockRejectedValueOnce(new Error('network down'));
+    expect((await readSiteFeatures()).sections.lightbox).toBe(false);
   });
 
   it('throws when the backend responds with a non-ok status', async () => {

--- a/lib/site-features-server.ts
+++ b/lib/site-features-server.ts
@@ -19,39 +19,43 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
+let lastGood: SiteFeaturesConfig | null = null;
+
+type SiteFeaturesRead = SiteFeaturesConfig & { degraded?: boolean };
+
+function degradedRead(): SiteFeaturesRead {
+  return { ...(lastGood ?? getDefaultConfig()), degraded: true };
+}
+
 /**
  * Site features are backend-owned (`AppSettings`, superuser-editable via the
- * backoffice). Any failure - network error, non-200, or an unexpected
- * response shape - falls back to defaults so SSR never 500s over a backend
- * hiccup (matches `readModelLabels`'s fallback behavior).
+ * backoffice). A failed read serves the last config this process saw — or the
+ * hardcoded defaults if it has seen none — so SSR never 500s over a backend
+ * hiccup, and flags it `degraded` so callers that must not act on a guess (the
+ * backoffice editor, the PUT's pre-write read) can refuse instead. The
+ * last-known-good is per-process and lost on restart: it bounds the window in
+ * which a blip re-enables everything an admin turned off, it does not close it.
  *
- * This fetch is on the critical path of every page render, so it must not
- * hit the backend on every request: the config only changes on an admin
- * PUT, so a short revalidation window (backstop) plus explicit
- * `revalidateTag` on write (immediate) is the right cache shape — see the
- * PUT handler in `app/api/app-settings/route.ts`. Without this, every single
- * page render round-trips to the backend, which is what let a backend
- * rate-limit hiccup degrade the whole site to hardcoded defaults for
- * `/site-labels/` (the same endpoint shape as this one) — see
- * `lib/model-labels-server.ts`.
+ * This fetch is on the critical path of every page render, so `revalidate: 60`
+ * (backstop) plus the tag the PUT handler purges (immediate) keeps it off the
+ * backend on every request.
  */
-export async function readSiteFeatures(): Promise<SiteFeaturesConfig> {
+export async function readSiteFeatures(): Promise<SiteFeaturesRead> {
   const defaults = getDefaultConfig();
   try {
     const res = await apiFetch(SITE_FEATURES_PATH, {
       next: { revalidate: 60, tags: [SITE_FEATURES_TAG] },
     });
-    if (!res.ok) return defaults; // apiFetch already logged the non-2xx above.
+    if (!res.ok) return degradedRead(); // apiFetch already logged the non-2xx above.
     const raw = await res.json();
     // If the response is `null`, an array, or a primitive, we'd crash on
-    // `parsed.sections` reading below. Bail out to defaults so the SSR
-    // layout doesn't 500 the whole site over a broken/unexpected response.
+    // `parsed.sections` reading below. Bail out so the SSR layout doesn't 500
+    // the whole site over a broken/unexpected response.
     if (!isPlainObject(raw)) {
       // A 200 with a malformed body isn't an HTTP-layer failure, so apiFetch
-      // never sees it — log it here or this degrades to defaults just as
-      // silently as the 429 that prompted this whole logging pass.
+      // never sees it — log it here or it degrades silently.
       console.error(`[API] GET ${SITE_FEATURES_PATH} → 200 with unexpected body shape`, raw);
-      return defaults;
+      return degradedRead();
     }
     const parsed = raw as Partial<SiteFeaturesConfig>;
     // Defensive: spreading a string or array into an object produces
@@ -61,7 +65,7 @@ export async function readSiteFeatures(): Promise<SiteFeaturesConfig> {
     // keys to consumers.
     const parsedSections = isPlainObject(parsed.sections) ? parsed.sections : {};
     const parsedCategories = isPlainObject(parsed.searchCategories) ? parsed.searchCategories : {};
-    return {
+    lastGood = {
       sections: { ...defaults.sections, ...parsedSections },
       sectionOrder: normalizeSectionOrder(parsed.sectionOrder),
       // Every config written before feature flags existed has no `features`
@@ -84,8 +88,9 @@ export async function readSiteFeatures(): Promise<SiteFeaturesConfig> {
         ),
       },
     };
+    return lastGood;
   } catch {
-    return defaults;
+    return degradedRead();
   }
 }
 

--- a/lib/site-features-server.ts
+++ b/lib/site-features-server.ts
@@ -24,15 +24,15 @@ let lastGood: SiteFeaturesConfig | null = null;
 type SiteFeaturesRead = SiteFeaturesConfig & { degraded?: boolean };
 
 function degradedRead(): SiteFeaturesRead {
-  return { ...(lastGood ?? getDefaultConfig()), degraded: true };
+  return { ...structuredClone(lastGood ?? getDefaultConfig()), degraded: true };
 }
 
 /**
  * Site features are backend-owned (`AppSettings`, superuser-editable via the
- * backoffice). A failed read serves the last config this process saw — or the
- * hardcoded defaults if it has seen none — so SSR never 500s over a backend
- * hiccup, and flags it `degraded` so callers that must not act on a guess (the
- * backoffice editor, the PUT's pre-write read) can refuse instead. The
+ * backoffice). A failed read serves the last config this process read or wrote —
+ * or the hardcoded defaults if it has seen none — so SSR never 500s over a
+ * backend hiccup, and flags it `degraded` so callers that must not act on a
+ * guess (the backoffice editor, the PUT's pre-write read) can refuse instead. The
  * last-known-good is per-process and lost on restart: it bounds the window in
  * which a blip re-enables everything an admin turned off, it does not close it.
  *
@@ -88,7 +88,9 @@ export async function readSiteFeatures(): Promise<SiteFeaturesRead> {
         ),
       },
     };
-    return lastGood;
+    // Cloned on the way out so a caller mutating its copy can't corrupt the
+    // process-wide last-known-good.
+    return structuredClone(lastGood);
   } catch {
     return degradedRead();
   }
@@ -124,6 +126,9 @@ export async function writeSiteFeatures(
   if (!res.ok) {
     throw new Error(`Failed to write site features: ${res.status}`);
   }
+  // What was just persisted is now the last-known-good; without this a backend
+  // failure right after a save serves the pre-write config back.
+  lastGood = structuredClone(normalized);
   // Return the normalized config so callers (e.g. the PUT route handler) can
   // echo back exactly what was persisted. Returning the input verbatim would
   // let the client's TanStack Query cache diverge from the backend on every

--- a/lib/site-features.ts
+++ b/lib/site-features.ts
@@ -31,15 +31,17 @@ export type SiteFeaturesConfig = {
   searchCategories: Record<ResultType, SearchCategoryConfig>;
 };
 
+/** Order matters: this is the default nav order, and it must match the backend
+ *  seed (`0010_seed_site_features.py`) and `config/site-features.json`. */
 export const ALL_SECTION_KEYS: SectionKey[] = [
   'search',
-  'collection',
   'lightbox',
-  'news',
+  'collection',
   'blogs',
   'featureArticles',
-  'events',
   'about',
+  'news',
+  'events',
 ];
 
 export const SECTION_LABELS: Record<SectionKey, string> = {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1815,6 +1815,7 @@
       "subtitle": "Enable or disable site features and configure search behaviour.",
       "toastSaved": "Site features saved",
       "toastFailedSave": "Failed to save site features",
+      "failedLoad": "Failed to load site features",
       "dragToReorder": "Drag to reorder",
       "reorderSection": "Reorder {section}",
       "sectionsTitle": "Site Sections",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1815,6 +1815,7 @@
       "subtitle": "Activer ou désactiver les fonctionnalités du site et configurer le comportement de la recherche.",
       "toastSaved": "Fonctionnalités du site enregistrées",
       "toastFailedSave": "Échec de l'enregistrement des fonctionnalités du site",
+      "failedLoad": "Échec du chargement des fonctionnalités du site",
       "dragToReorder": "Glisser pour réorganiser",
       "reorderSection": "Réorganiser {section}",
       "sectionsTitle": "Sections du site",

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,29 @@
+/** @vitest-environment node */
+import { NextRequest } from 'next/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { proxy } from './proxy';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('proxy section gating', () => {
+  it('keeps a disabled section blocked once the config read starts failing', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ sections: { lightbox: false }, searchCategories: {} }))
+    );
+    const first = await proxy(new NextRequest('http://localhost:3000/lightbox'));
+    expect(first.headers.get('x-middleware-rewrite')).toContain('/not-found');
+
+    vi.advanceTimersByTime(11_000);
+    fetchMock.mockRejectedValueOnce(new Error('backend down'));
+    const second = await proxy(new NextRequest('http://localhost:3000/lightbox'));
+    expect(second.headers.get('x-middleware-rewrite')).toContain('/not-found');
+  });
+});

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,8 +1,15 @@
 /** @vitest-environment node */
 import { NextRequest } from 'next/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { proxy } from './proxy';
+// Re-imported per test (after `vi.resetModules`) so the module-scope config
+// cache starts empty each time.
+let proxy: typeof import('./proxy').proxy;
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ proxy } = await import('./proxy'));
+});
 
 afterEach(() => {
   vi.useRealTimers();
@@ -25,5 +32,24 @@ describe('proxy section gating', () => {
     fetchMock.mockRejectedValueOnce(new Error('backend down'));
     const second = await proxy(new NextRequest('http://localhost:3000/lightbox'));
     expect(second.headers.get('x-middleware-rewrite')).toContain('/not-found');
+  });
+
+  it('still throttles config fetches to one per TTL while the backend is down', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ sections: {}, searchCategories: {} }))
+    );
+    await proxy(new NextRequest('http://localhost:3000/'));
+
+    vi.advanceTimersByTime(11_000);
+    fetchMock.mockRejectedValue(new Error('backend down'));
+    await proxy(new NextRequest('http://localhost:3000/'));
+    await proxy(new NextRequest('http://localhost:3000/'));
+    await proxy(new NextRequest('http://localhost:3000/'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/proxy.ts
+++ b/proxy.ts
@@ -82,8 +82,11 @@ async function loadConfig(origin: string): Promise<MinConfig> {
   }
 
   // An expired config beats none: an empty one routes every section an admin
-  // disabled until the backend recovers.
-  return cachedConfig ?? { sections: {}, searchCategories: {} };
+  // disabled. Refreshing the timestamp on failure keeps a sustained outage
+  // throttled to one attempt per TTL instead of one per page view.
+  cachedConfig ??= { sections: {}, searchCategories: {} };
+  cacheTimestamp = now;
+  return cachedConfig;
 }
 
 export async function proxy(request: NextRequest) {

--- a/proxy.ts
+++ b/proxy.ts
@@ -78,10 +78,12 @@ async function loadConfig(origin: string): Promise<MinConfig> {
       return cachedConfig;
     }
   } catch {
-    // Fall through to defaults
+    // Fall through to the last known config
   }
 
-  return { sections: {}, searchCategories: {} };
+  // An expired config beats none: an empty one routes every section an admin
+  // disabled until the backend recovers.
+  return cachedConfig ?? { sections: {}, searchCategories: {} };
 }
 
 export async function proxy(request: NextRequest) {


### PR DESCRIPTION
Follow-up to the review on #111 — takes items 2-5 of "What I'd do next". Branches off #111's head and targets `fix/wire-site-features-to-backend2`, so it can be merged straight into the PR. The full argument is in the [review](https://github.com/archetype-pal/frontend/pull/111); this is just what changed.

## What it fixes

**The editor can no longer erase the stored config.** `readSiteFeatures` flags its fallback `degraded`, `GET /api/app-settings` answers `503` instead of serving the defaults as a healthy `200`, and the backoffice renders the shared error state rather than a form full of defaults. The PUT's pre-write read gets the same treatment: it refuses with a `503` rather than merging the payload over a guess. Previously a 20-second API restart was enough — an admin opens the page mid-blip, sees every section enabled and every column and facet at its default with no indication anything is wrong, flips one toggle, and the save deletes every configured selection, every disabled section and the custom `sectionOrder`.

**A blip no longer unlocks everything.** A module-scope last-known-good means a failed read serves the config this process last saw instead of the all-permissive defaults, and `proxy.ts` holds its expired config instead of falling back to an empty one — without that, the section gate still failed open on every degraded read. A successful *write* updates the last-known-good too, so a read that fails right after a save no longer serves the pre-write config back and re-enables what the admin just turned off. `readSiteFeatures` hands out a clone rather than the module object itself, so a consumer mutation can't corrupt what every later visitor is served. The last-known-good is per-process and lost on restart: it bounds the fail-open window rather than closing it, and the doc comment says so.

**The 503 doesn't cost anything on the outage path.** `proxy.ts` refreshes its cache timestamp on the failure path as well as the success path. The old `200`-with-fallback body was accidentally keeping that throttle alive; without the refresh the `503` would have turned a backend outage into one extra `/api/app-settings` + Django round trip per HTML page view, on a matcher that covers every page. Either way it stays at one attempt per 10s TTL, and a cold start with the backend already down is throttled too.

**Smaller things:** `revalidateTag(SITE_FEATURES_TAG, { expire: 0 })` actually purges the cached fetch entry (`'minutes'` only marked it stale, and a stale entry still serves the old body — the comment claiming otherwise is gone; `revalidatePath` stays, it's load-bearing); the 502 branch logs the upstream reason instead of swallowing it; `ALL_SECTION_KEYS` is reordered to match `config/site-features.json` and api#149's `DEFAULT_SITE_FEATURES` + seed migration, so a degraded read no longer reshuffles the public nav; and `app/layout.tsx` drops `degraded` before it reaches `SiteFeaturesProvider`, so backend health isn't serialized into the public RSC payload.

**Tests.** Two new files (`app/backoffice/site-features/page.test.tsx`, `proxy.test.ts`) plus additions to three existing ones: the degraded paths, the last-known-good behaviour on both read and write, the proxy's retry throttle under a sustained outage, the clone-on-return, the `revalidateTag` argument (the existing `next/cache` mock was a bare `vi.fn()` nothing asserted, which is why the wrong profile went unnoticed), and the default section order pinned to the checked-in JSON. `proxy.test.ts` re-imports the module per test — the config cache is module-scope, and without that reset the second test measured nothing. Each assertion added in the follow-up commit was watched failing with its source change reverted and passing with it restored.

## Known gap

Review item 5 is only partly closed. The PUT's pre-write read no longer merges over *defaults*, but it is still cache-mediated: it carries `next: { revalidate: 60 }`, so across Next instances — or within 60s of another instance's write — the PUT can still merge its payload over a stale `features` map. Much narrower than the defaults case, and the durable fix is the backend serializer in #149, so it is left open rather than papered over here.

## What you need to decide

1. **Merge sequencing is still yours.** Nothing here makes merging before api#149 safe — every read still 404s and every save still fails. It makes the failure loud instead of silent: the backoffice shows a load error rather than an inert form, and the public nav keeps its order because the defaults now match the seed.
2. **The 503 body is deliberately opaque** (`{ error: 'Site features unavailable' }`). `proxy.ts` only checks `res.ok`, so it discards the body either way; if you'd rather the editor showed the upstream status, that's a one-line change to the route.
3. **`readSiteFeatures` stays one function** rather than the strict/lenient split the review proposed — it returns an optional `degraded` flag instead. Same three call sites, one fewer export, and it matches the shape the #105 follow-up used for model labels.

Also deliberately left alone: everything in the review's "nine smaller things" — the `sections`/`searchCategories` whitelist gap (the durable fix is in #149's serializer), the `lib/api-fetch.ts` nits (that file is also touched by the #105 follow-up, so touching it here would only create a conflict), the missing `/api/site-features` alias, the now-vestigial `config/site-features.json` guard, the four duplicate `verifySuperuser` copies, and the stale docs. Item 8 (`res.json()` rejecting logs nothing) is not separately logged either: the fallback is now visible as a 503 and a backoffice error, and a log there would double every network failure `apiFetch` already reports.

Green on `pnpm lint`, `pnpm format`, `pnpm tsc --noEmit`, `pnpm test` (117 files / 1173 tests), `pnpm build`, and `pnpm bundle-budget` (1.90 / 2.05 MiB gzip). If you run the suite on a tree that still has a `.next/` from a previous `pnpm build` you'll get 118 / 1178 instead — vitest's default exclude doesn't cover `.next`, so it also collects the standalone build's copy of `config/site-features.test.ts`. CI's test job runs without a build, so 117 / 1173 is the number that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

Follows the review on #111. Branched off #111's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)