### PR TITLE
fix(uploads): close the cancel-during-finalize window and make the poll tests real (review follow-up to #98)

### DIFF
--- a/app/backoffice/search-engine/page.tsx
+++ b/app/backoffice/search-engine/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/auth-context';
+import { useUploadManager } from '@/contexts/upload-manager-context';
 import { toast } from 'sonner';
 import {
   Search,
@@ -738,15 +739,16 @@ function TaskProgressPanel({
   t: ReturnType<typeof useTranslations>;
 }) {
   const [collapsed, setCollapsed] = useState(false);
+  const { items, interrupted } = useUploadManager();
   const completedCount = tasks.filter(
     (task) => task.status && ['SUCCESS', 'FAILURE'].includes(task.status.state)
   ).length;
 
   return (
     <FloatingPanel
-      // Step aside: the shell-level upload tray owns the bottom-right corner
-      // (panel width 380px + the 16px gutter it sits in).
-      className="right-[412px]"
+      // Step aside only while the shell-level upload tray is actually rendered
+      // in the bottom-right corner (its 380px width + the 16px gutter).
+      className={items.length + interrupted.length > 0 ? 'right-[412px]' : undefined}
       title={t('searchEngine.tasksPanelTitle', { count: tasks.length })}
       icon={<Activity className="h-4 w-4 text-primary" />}
       collapsed={collapsed}

--- a/app/backoffice/search-engine/page.tsx
+++ b/app/backoffice/search-engine/page.tsx
@@ -744,6 +744,9 @@ function TaskProgressPanel({
 
   return (
     <FloatingPanel
+      // Step aside: the shell-level upload tray owns the bottom-right corner
+      // (panel width 380px + the 16px gutter it sits in).
+      className="right-[412px]"
       title={t('searchEngine.tasksPanelTitle', { count: tasks.length })}
       icon={<Activity className="h-4 w-4 text-primary" />}
       collapsed={collapsed}

--- a/components/backoffice/manuscripts/item-image-upload-dialog.tsx
+++ b/components/backoffice/manuscripts/item-image-upload-dialog.tsx
@@ -237,8 +237,11 @@ function StagedFileItem({
           </div>
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-1">
-              <Label className="text-[10px] text-muted-foreground">Locus</Label>
+              <Label htmlFor={`locus-${staged.id}`} className="text-[10px] text-muted-foreground">
+                Locus
+              </Label>
               <Input
+                id={`locus-${staged.id}`}
                 value={staged.locus}
                 onChange={(e) => onLocusChange(e.target.value)}
                 placeholder="e.g. f.1r"
@@ -246,8 +249,11 @@ function StagedFileItem({
               />
             </div>
             <div className="space-y-1">
-              <Label className="text-[10px] text-muted-foreground">Tags</Label>
+              <Label htmlFor={`tags-${staged.id}`} className="text-[10px] text-muted-foreground">
+                Tags
+              </Label>
               <Input
+                id={`tags-${staged.id}`}
                 value={staged.tags}
                 onChange={(e) => onTagsChange(e.target.value)}
                 placeholder="comma,separated"

--- a/components/backoffice/uploads/upload-tray.test.tsx
+++ b/components/backoffice/uploads/upload-tray.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UploadTray } from './upload-tray';
@@ -49,10 +49,19 @@ function renderTray(over: Partial<UploadItem>) {
 beforeEach(() => vi.clearAllMocks());
 
 describe('upload tray X button', () => {
-  it('cancels while bytes are still in flight', () => {
-    renderTray({ status: 'uploading' });
+  it('cancels bytes in flight, but only stops tracking once finalize has started', () => {
+    renderTray({ phase: 'uploading' });
     fireEvent.click(screen.getByLabelText('Cancel upload of f12r.tif'));
     expect(cancel).toHaveBeenCalledWith('i1');
+
+    // Same status, later phase: finalize is already assembling server-side, so
+    // a DELETE would either lose the race or corrupt it.
+    cleanup();
+    renderTray({ phase: 'finalizing' });
+    expect(screen.queryByLabelText('Cancel upload of f12r.tif')).toBeNull();
+    fireEvent.click(screen.getByLabelText('Stop tracking f12r.tif'));
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(dismiss).toHaveBeenCalledWith('i1');
   });
 
   it('drops a queued upload instead of trapping it behind a disabled button', () => {

--- a/components/backoffice/uploads/upload-tray.test.tsx
+++ b/components/backoffice/uploads/upload-tray.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UploadTray } from './upload-tray';
+import { useUploadManager, type UploadItem } from '@/contexts/upload-manager-context';
+
+vi.mock('@/contexts/upload-manager-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/contexts/upload-manager-context')>();
+  return { ...actual, useUploadManager: vi.fn() };
+});
+
+const cancel = vi.fn();
+const dismiss = vi.fn();
+
+const item = (over: Partial<UploadItem>): UploadItem => ({
+  id: 'i1',
+  file: new File(['x'], 'f12r.tif'),
+  fileName: 'f12r.tif',
+  itemPartId: 3,
+  itemPartLabel: 'MS A, part 1',
+  historicalItemId: 7,
+  locus: 'f.12r',
+  tags: '',
+  status: 'uploading',
+  phase: 'uploading',
+  sentBytes: 1,
+  totalBytes: 4,
+  message: '',
+  error: '',
+  ...over,
+});
+
+function renderTray(over: Partial<UploadItem>) {
+  vi.mocked(useUploadManager).mockReturnValue({
+    items: [item(over)],
+    activeCount: 1,
+    interrupted: [],
+    enqueue: vi.fn(),
+    cancel,
+    retry: vi.fn(),
+    dismiss,
+    clearFinished: vi.fn(),
+    resumeInterrupted: vi.fn(),
+    dismissInterrupted: vi.fn(),
+  });
+  render(<UploadTray />);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('upload tray X button', () => {
+  it('cancels while bytes are still in flight', () => {
+    renderTray({ status: 'uploading' });
+    fireEvent.click(screen.getByLabelText('Cancel upload of f12r.tif'));
+    expect(cancel).toHaveBeenCalledWith('i1');
+  });
+
+  it('drops a queued upload instead of trapping it behind a disabled button', () => {
+    renderTray({ status: 'pending', phase: null });
+    fireEvent.click(screen.getByLabelText('Cancel upload of f12r.tif'));
+    expect(cancel).toHaveBeenCalledWith('i1');
+  });
+
+  it('only stops tracking once the server is converting — that cannot be cancelled', () => {
+    renderTray({ status: 'processing', phase: 'processing' });
+    expect(screen.queryByLabelText('Cancel upload of f12r.tif')).toBeNull();
+    fireEvent.click(screen.getByLabelText('Stop tracking f12r.tif'));
+    expect(cancel).not.toHaveBeenCalled();
+    expect(dismiss).toHaveBeenCalledWith('i1');
+  });
+});

--- a/components/backoffice/uploads/upload-tray.tsx
+++ b/components/backoffice/uploads/upload-tray.tsx
@@ -198,6 +198,9 @@ function UploadTrayItem({
   onDismiss: () => void;
 }) {
   const active = item.status === 'uploading' || item.status === 'processing';
+  // Only bytes in flight can be called back — a converting session refuses to
+  // abort, so its X stops tracking rather than promise a cancel it can't do.
+  const cancellable = item.status === 'pending' || item.status === 'uploading';
   // A recovered watch item has no File in memory — nothing to retry with.
   const retryable = RETRYABLE_STATUSES.includes(item.status) && item.file != null;
   const pct =
@@ -274,9 +277,14 @@ function UploadTrayItem({
             variant="ghost"
             size="icon"
             className="h-6 w-6"
-            aria-label={active ? `Cancel upload of ${item.fileName}` : `Dismiss ${item.fileName}`}
-            onClick={active ? onCancel : onDismiss}
-            disabled={item.status === 'pending'}
+            aria-label={
+              cancellable
+                ? `Cancel upload of ${item.fileName}`
+                : item.status === 'processing'
+                  ? `Stop tracking ${item.fileName}`
+                  : `Dismiss ${item.fileName}`
+            }
+            onClick={cancellable ? onCancel : onDismiss}
           >
             <X className="h-3.5 w-3.5" />
           </Button>

--- a/components/backoffice/uploads/upload-tray.tsx
+++ b/components/backoffice/uploads/upload-tray.tsx
@@ -198,9 +198,12 @@ function UploadTrayItem({
   onDismiss: () => void;
 }) {
   const active = item.status === 'uploading' || item.status === 'processing';
-  // Only bytes in flight can be called back — a converting session refuses to
-  // abort, so its X stops tracking rather than promise a cancel it can't do.
-  const cancellable = item.status === 'pending' || item.status === 'uploading';
+  // Only bytes still in flight can be called back. Once finalize is posted the
+  // server is assembling and then converting, and a DELETE would either lose
+  // the race (the image publishes anyway) or pull the chunks out from under
+  // it — so from 'finalizing' on, the X stops tracking instead.
+  const cancellable =
+    item.status === 'pending' || (item.status === 'uploading' && item.phase !== 'finalizing');
   // A recovered watch item has no File in memory — nothing to retry with.
   const retryable = RETRYABLE_STATUSES.includes(item.status) && item.file != null;
   const pct =
@@ -280,7 +283,7 @@ function UploadTrayItem({
             aria-label={
               cancellable
                 ? `Cancel upload of ${item.fileName}`
-                : item.status === 'processing'
+                : active
                   ? `Stop tracking ${item.fileName}`
                   : `Dismiss ${item.fileName}`
             }

--- a/contexts/upload-manager-context.test.tsx
+++ b/contexts/upload-manager-context.test.tsx
@@ -278,8 +278,9 @@ describe('resume & dismiss', () => {
     expect(mockedUpload).not.toHaveBeenCalled();
   });
 
-  it('dismiss deletes the breadcrumb for good', async () => {
-    seedCrumb();
+  it('dismiss deletes the breadcrumb and the server session with it', async () => {
+    seedCrumb({ sessionId: 's1' });
+    mockedGetSession.mockRejectedValue(new Error('offline'));
     renderHarness();
     await waitFor(() =>
       expect(screen.getByTestId('interrupted').textContent).toContain('f12r.tif')
@@ -287,6 +288,8 @@ describe('resume & dismiss', () => {
 
     fireEvent.click(screen.getByText('dismiss interrupted'));
     await waitFor(() => expect(screen.getByTestId('interrupted').textContent).toBe(''));
+    // Discarding the last handle on a session must free its chunks too.
+    expect(mockedAbort).toHaveBeenCalledWith('tok', 's1');
     expect(listUploadBreadcrumbs()).toEqual([]);
   });
 });

--- a/contexts/upload-manager-context.test.tsx
+++ b/contexts/upload-manager-context.test.tsx
@@ -17,6 +17,7 @@ import {
   type UploadBreadcrumb,
 } from '@/lib/backoffice/upload-breadcrumbs';
 import {
+  abortUploadSession,
   getUploadSession,
   uploadImageFile,
   watchUploadSession,
@@ -46,12 +47,14 @@ vi.mock('@/services/backoffice/uploads', async (importOriginal) => {
     uploadImageFile: vi.fn(),
     getUploadSession: vi.fn(),
     watchUploadSession: vi.fn(),
+    abortUploadSession: vi.fn(() => Promise.resolve()),
   };
 });
 
 const mockedUpload = vi.mocked(uploadImageFile);
 const mockedGetSession = vi.mocked(getUploadSession);
 const mockedWatch = vi.mocked(watchUploadSession);
+const mockedAbort = vi.mocked(abortUploadSession);
 
 const session = (over: Partial<UploadSession> = {}): UploadSession => ({
   id: 's1',
@@ -99,7 +102,7 @@ function seedCrumb(over: Partial<UploadBreadcrumb> = {}): void {
 const makeFile = (name: string, bytes: number) => new File(['x'.repeat(bytes)], name);
 
 function Harness() {
-  const { items, interrupted, enqueue, retry, resumeInterrupted, dismissInterrupted } =
+  const { items, interrupted, enqueue, cancel, retry, resumeInterrupted, dismissInterrupted } =
     useUploadManager();
   const [resume, setResume] = useState<ResumeResult | null>(null);
   return (
@@ -137,6 +140,9 @@ function Harness() {
       </button>
       <button type="button" onClick={() => items[0] && retry(items[0].id)}>
         retry first
+      </button>
+      <button type="button" onClick={() => items[0] && cancel(items[0].id)}>
+        cancel first
       </button>
     </div>
   );
@@ -371,6 +377,41 @@ describe('multi-tab ownership', () => {
     fireEvent.click(screen.getByText('enqueue one'));
     await waitFor(() => expect(screen.getByTestId('items').textContent).toContain('new.tif:busy'));
     expect(listUploadBreadcrumbs().map((c) => c.id)).toEqual(['a-elder']);
+  });
+});
+
+describe('cancel', () => {
+  it('discards the server session and the breadcrumb with it', async () => {
+    mockedUpload.mockImplementation((_token, _file, _meta, options) => {
+      options?.onProgress?.({
+        phase: 'uploading',
+        sentBytes: 1,
+        totalBytes: 4,
+        session: session({ id: 's-new' }),
+      });
+      return new Promise((_resolve, reject) =>
+        options?.signal?.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        )
+      );
+    });
+    renderHarness();
+
+    fireEvent.click(screen.getByText('enqueue one'));
+    await waitFor(() =>
+      expect(screen.getByTestId('items').textContent).toContain('new.tif:uploading')
+    );
+
+    fireEvent.click(screen.getByText('cancel first'));
+    await waitFor(() =>
+      expect(screen.getByTestId('items').textContent).toContain('new.tif:canceled')
+    );
+    // Without the DELETE the half-uploaded chunks stay on disk and the session
+    // keeps the destination reserved against every other editor.
+    expect(mockedAbort).toHaveBeenCalledWith('tok', 's-new');
+    // Keeping the crumb (as 'canceled') would have a reload re-offer the
+    // upload the editor just stopped as "interrupted by a reload".
+    expect(listUploadBreadcrumbs()).toEqual([]);
   });
 });
 

--- a/contexts/upload-manager-context.tsx
+++ b/contexts/upload-manager-context.tsx
@@ -392,7 +392,8 @@ export function UploadManagerProvider({ children }: { children: React.ReactNode 
 
   /** Fire-and-forget: a failed abort leaves nothing the user could act on. */
   const abortSession = useCallback((sessionId: string) => {
-    if (sessionId) void abortUploadSession(tokenRef.current ?? '', sessionId).catch(() => {});
+    const authToken = tokenRef.current;
+    if (sessionId && authToken) void abortUploadSession(authToken, sessionId).catch(() => {});
   }, []);
 
   const cancel = useCallback(

--- a/contexts/upload-manager-context.tsx
+++ b/contexts/upload-manager-context.tsx
@@ -29,6 +29,7 @@ import {
   type UploadBreadcrumb,
 } from '@/lib/backoffice/upload-breadcrumbs';
 import {
+  abortUploadSession,
   describeUploadError,
   getUploadSession,
   isConflictError,
@@ -331,7 +332,7 @@ export function UploadManagerProvider({ children }: { children: React.ReactNode 
               removeUploadBreadcrumbs([id]);
             } else {
               patch(id, { status: 'canceled' });
-              updateUploadBreadcrumb(id, { status: 'canceled' });
+              removeUploadBreadcrumbs([id]);
             }
           } else if (isConflictError(err)) {
             // A duplicate proves the image already exists server-side — refresh
@@ -389,17 +390,21 @@ export function UploadManagerProvider({ children }: { children: React.ReactNode 
     [drain]
   );
 
+  /** Fire-and-forget: a failed abort leaves nothing the user could act on. */
+  const abortSession = useCallback((sessionId: string) => {
+    if (sessionId) void abortUploadSession(tokenRef.current ?? '', sessionId).catch(() => {});
+  }, []);
+
   const cancel = useCallback(
     (id: string) => {
+      abortSession(listUploadBreadcrumbs().find((c) => c.id === id)?.sessionId ?? '');
+      removeUploadBreadcrumbs([id]);
       const controller = controllers.current.get(id);
       if (controller) controller.abort();
       // Not yet started: mark canceled so the runner skips it when reached.
-      else {
-        patch(id, { status: 'canceled' });
-        updateUploadBreadcrumb(id, { status: 'canceled' });
-      }
+      else patch(id, { status: 'canceled' });
     },
-    [patch]
+    [abortSession, patch]
   );
 
   const retry = useCallback(
@@ -418,6 +423,9 @@ export function UploadManagerProvider({ children }: { children: React.ReactNode 
   );
 
   const dismiss = useCallback((id: string) => {
+    // Dismissing a `processing` row means "stop tracking": the server-side
+    // conversion finishes either way, so only the polling loop is dropped.
+    controllers.current.get(id)?.abort();
     itemsRef.current.delete(id);
     removeUploadBreadcrumbs([id]);
     setItems((prev) => prev.filter((it) => it.id !== id));
@@ -607,11 +615,15 @@ export function UploadManagerProvider({ children }: { children: React.ReactNode 
     [addItem, drain]
   );
 
-  const dismissInterrupted = useCallback((id: string) => {
-    removeUploadBreadcrumbs([id]);
-    promptOnlyRef.current.delete(id);
-    setInterrupted((prev) => prev.filter((c) => c.id !== id));
-  }, []);
+  const dismissInterrupted = useCallback(
+    (id: string) => {
+      abortSession(interruptedRef.current.find((c) => c.id === id)?.sessionId ?? '');
+      removeUploadBreadcrumbs([id]);
+      promptOnlyRef.current.delete(id);
+      setInterrupted((prev) => prev.filter((c) => c.id !== id));
+    },
+    [abortSession]
+  );
 
   const activeCount = items.filter((it) => !UPLOAD_TERMINAL_STATUSES.includes(it.status)).length;
 

--- a/lib/backoffice/upload-helpers.test.ts
+++ b/lib/backoffice/upload-helpers.test.ts
@@ -36,6 +36,11 @@ describe('guessLocusFromFilename', () => {
     expect(guessLocusFromFilename('scan_0001.jpg')).toBe('');
     expect(guessLocusFromFilename('cover.png')).toBe('');
   });
+
+  it('refuses to invent a locus from the tail of a longer number', () => {
+    expect(guessLocusFromFilename('Add_ch_33792r.tif')).toBe('');
+    expect(guessLocusFromFilename('MS_12345v.tif')).toBe('');
+  });
 });
 
 describe('planChunks', () => {

--- a/lib/backoffice/upload-helpers.test.ts
+++ b/lib/backoffice/upload-helpers.test.ts
@@ -40,6 +40,8 @@ describe('guessLocusFromFilename', () => {
   it('refuses to invent a locus from the tail of a longer number', () => {
     expect(guessLocusFromFilename('Add_ch_33792r.tif')).toBe('');
     expect(guessLocusFromFilename('MS_12345v.tif')).toBe('');
+    // Accepted cost: a zero-padded 5-digit locus loses its suggestion too.
+    expect(guessLocusFromFilename('Cotton_Nero_D_IV_f_00027r.tif')).toBe('');
   });
 });
 

--- a/lib/backoffice/upload-helpers.ts
+++ b/lib/backoffice/upload-helpers.ts
@@ -35,10 +35,11 @@ export function isAcceptedImageFilename(filename: string): boolean {
  *   0032v.jp2      → f.32v
  *   MS_Add_1234_f005r.tiff → f.5r
  *   scan_0001.jpg  → ''  (no r/v side, ambiguous)
+ *   Add_ch_33792r.tif → ''  (>4 digits; `(?<!\d)` stops it matching a tail)
  */
 export function guessLocusFromFilename(filename: string): string {
   const stem = filename.replace(/\.[^.]+$/, '');
-  const matches = [...stem.matchAll(/(\d{1,4})\s*([rv])\b/gi)];
+  const matches = [...stem.matchAll(/(?<!\d)(\d{1,4})\s*([rv])\b/gi)];
   if (matches.length === 0) return '';
   const last = matches[matches.length - 1];
   const number = String(parseInt(last[1], 10));

--- a/lib/backoffice/upload-helpers.ts
+++ b/lib/backoffice/upload-helpers.ts
@@ -35,7 +35,9 @@ export function isAcceptedImageFilename(filename: string): boolean {
  *   0032v.jp2      → f.32v
  *   MS_Add_1234_f005r.tiff → f.5r
  *   scan_0001.jpg  → ''  (no r/v side, ambiguous)
- *   Add_ch_33792r.tif → ''  (>4 digits; `(?<!\d)` stops it matching a tail)
+ *   Add_ch_33792r.tif → ''  (`(?<!\d)` blanks any run over 4 digits rather
+ *                            than guess from its tail — zero-padded 5-digit
+ *                            loci lose their suggestion too, deliberately)
  */
 export function guessLocusFromFilename(filename: string): string {
   const stem = filename.replace(/\.[^.]+$/, '');

--- a/services/backoffice/uploads.test.ts
+++ b/services/backoffice/uploads.test.ts
@@ -169,11 +169,12 @@ describe('watchUploadSession', () => {
     expect(result.status).toBe('complete');
   });
 
-  it('gives up once the failures stop looking transient', async () => {
+  it('gives up on the sixth consecutive failure, not the first', async () => {
     mockedGet.mockRejectedValue(new Error('API gone'));
     await expect(watchUploadSession('tok', session(), { pollIntervalMs: 0 })).rejects.toThrow(
       'API gone'
     );
+    expect(mockedGet).toHaveBeenCalledTimes(6); // MAX_POLL_FAILURES + 1
   });
 
   it('stops with AbortError when the signal is already aborted', async () => {

--- a/services/backoffice/uploads.test.ts
+++ b/services/backoffice/uploads.test.ts
@@ -50,8 +50,16 @@ describe('describeUploadError', () => {
     expect(describeUploadError(err)).not.toBe('API error 409');
   });
 
-  it('falls back to a status message when the body has no detail', () => {
-    expect(describeUploadError(new BackofficeApiError(500, {}))).toBe('Request failed (500).');
+  it('names the offending field on a DRF validation 400', () => {
+    const err = new BackofficeApiError(400, {
+      tags: ['Ensure this field has no more than 255 characters.'],
+    });
+    expect(describeUploadError(err)).toContain('tags');
+    expect(describeUploadError(err)).toContain('no more than 255');
+  });
+
+  it('falls back to a status message when the body says nothing', () => {
+    expect(describeUploadError(new BackofficeApiError(500, {}))).toBe('Server error (500)');
   });
 
   it('handles chunk, upload-failed, generic and unknown errors', () => {
@@ -60,7 +68,7 @@ describe('describeUploadError', () => {
       'conversion died'
     );
     expect(describeUploadError(new Error('boom'))).toBe('boom');
-    expect(describeUploadError('weird')).toBe('Upload failed.');
+    expect(describeUploadError('weird')).toBe('An unexpected error occurred');
   });
 });
 
@@ -147,6 +155,24 @@ describe('watchUploadSession', () => {
     mockedGet.mockResolvedValueOnce(session({ status: 'failed', error: 'tile smoke test failed' }));
     await expect(watchUploadSession('tok', session(), { pollIntervalMs: 0 })).rejects.toThrow(
       'tile smoke test failed'
+    );
+  });
+
+  it('rides out a burst of unreadable polls instead of failing a live conversion', async () => {
+    mockedGet
+      .mockRejectedValueOnce(new Error('API restarting'))
+      .mockRejectedValueOnce(new Error('API restarting'))
+      .mockRejectedValueOnce(new Error('API restarting'))
+      .mockResolvedValueOnce(session({ status: 'complete', item_image: 9 }));
+
+    const result = await watchUploadSession('tok', session(), { pollIntervalMs: 0 });
+    expect(result.status).toBe('complete');
+  });
+
+  it('gives up once the failures stop looking transient', async () => {
+    mockedGet.mockRejectedValue(new Error('API gone'));
+    await expect(watchUploadSession('tok', session(), { pollIntervalMs: 0 })).rejects.toThrow(
+      'API gone'
     );
   });
 

--- a/services/backoffice/uploads.ts
+++ b/services/backoffice/uploads.ts
@@ -1,5 +1,6 @@
-import { backofficeGet, backofficePost, BackofficeApiError } from './api-client';
+import { backofficeDelete, backofficeGet, backofficePost, BackofficeApiError } from './api-client';
 import { API_BASE_URL } from '@/lib/api-fetch';
+import { formatApiError } from '@/lib/backoffice/format-api-error';
 import { planChunks } from '@/lib/backoffice/upload-helpers';
 
 /* ------------------------------------------------------------------ */
@@ -75,6 +76,11 @@ export function finalizeUploadSession(token: string, id: string): Promise<Upload
   return backofficePost<UploadSession>(`${BASE}${id}/finalize/`, token, {});
 }
 
+/** Discard a session server-side, freeing its destination and chunk files. */
+export function abortUploadSession(token: string, id: string): Promise<void> {
+  return backofficeDelete(`${BASE}${id}/`, token);
+}
+
 /* ------------------------------------------------------------------ */
 /*  Chunk transport (XHR — fetch cannot report upload progress)        */
 /* ------------------------------------------------------------------ */
@@ -139,7 +145,9 @@ function putChunk(
         resolve();
       } else {
         // Full body to the console for developers; a sanitized detail to the UI.
-        console.error(`Chunk ${index} upload failed (${xhr.status}):`, xhr.responseText);
+        if (process.env.NODE_ENV === 'development') {
+          console.error(`Chunk ${index} upload failed (${xhr.status}):`, xhr.responseText);
+        }
         reject(new ChunkUploadError(xhr.status, chunkErrorDetail(xhr.status, xhr.responseText)));
       }
     };
@@ -216,22 +224,19 @@ export function isConflictError(err: unknown): boolean {
 }
 
 /**
- * Human-readable reason for an upload failure. Prefers the backend's `detail`
- * string (e.g. "A file already exists at '…'. Uploads never overwrite.") over
- * the generic "API error 409" that BackofficeApiError.message carries.
+ * Human-readable reason for an upload failure. `formatApiError` covers the
+ * backend's `detail` string and DRF's field-shaped 400s; only a chunk error
+ * needs special handling, because its `message` embeds the raw status.
  */
 export function describeUploadError(err: unknown): string {
-  if (err instanceof BackofficeApiError) {
-    const detail = err.body?.detail;
-    return typeof detail === 'string' && detail ? detail : `Request failed (${err.status}).`;
-  }
   if (err instanceof ChunkUploadError) return err.detail || err.message;
-  if (err instanceof UploadFailedError) return err.message;
-  if (err instanceof Error) return err.message;
-  return 'Upload failed.';
+  return formatApiError(err);
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Consecutive poll failures tolerated before a conversion is called dead. */
+const MAX_POLL_FAILURES = 5;
 
 /**
  * Poll an already-finalized session until the server-side conversion reaches
@@ -253,13 +258,21 @@ export async function watchUploadSession(
     onProgress?.({ totalBytes: total, ...progress });
 
   const deadline = Date.now() + processTimeoutMs;
+  let failures = 0;
   while (session.status !== 'complete' && session.status !== 'failed') {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     if (Date.now() > deadline) {
       throw new UploadFailedError('Timed out waiting for server-side processing.', session);
     }
     await sleep(pollIntervalMs);
-    session = await getUploadSession(token, session.id);
+    try {
+      session = await getUploadSession(token, session.id);
+      failures = 0;
+    } catch (err) {
+      // A conversion runs for minutes; one unreadable status is not a verdict.
+      if (++failures > MAX_POLL_FAILURES) throw err;
+      continue;
+    }
     report({
       phase: 'processing',
       sentBytes: total,


### PR DESCRIPTION
Follow-up to [the review on #98](https://github.com/archetype-pal/frontend/pull/98#pullrequestreview-4945594592), branched from `b95d557` and targeting `feat-72/image-upload-ui`. Take it, cherry-pick from it, or ignore it.

## What this fixes

**Three paths reported a succeeded upload as a failure.** All three ended with the editor being told the image did not upload while Celery published it anyway, and with Retry turning that into a second, louder error.

- **Cancel during the finalize/convert window** aborted nothing useful — finalize had already returned and `ingest_upload.delay(...)` was already dispatched — but the tray said "Canceled", and Retry then hit the backend's session-collision check and became a red *"Another upload session is already targeting…"*. The window is wider than the visible `Converting to JP2…`: `uploadImageFile` reports `phase: 'finalizing'` and the manager collapses that to `status: 'uploading'`, so the row *looks* like it is still sending bytes for the whole finalize POST — tens of seconds to minutes on a multi-GB scan. The X therefore now cancels only while `status === 'uploading' && phase !== 'finalizing'` (or the row is still queued); from `finalizing` on it reads **Stop tracking** and calls `dismiss`, which drops the polling loop and leaves the server-side conversion alone. A queued row can now be dropped too, rather than sitting behind a disabled X with a reload as its only escape.
- **One unreadable poll** killed a live conversion. `fetchWithRetry` gives GETs about 1.5 s, so any API restart inside a twelve-minute conversion produced "Upload failed" for an image that exists. `watchUploadSession` now tolerates five consecutive failures (it gives up on the sixth call); the existing process deadline still bounds the loop.
- **Cancel never called `DELETE /uploads/sessions/{id}/`**, so a cancelled 3 GB scan left its chunks on disk and its session holding the destination against every other editor, with no affordance to clear it. Cancel and dismiss-interrupted now abort the session.

**A cancelled upload came back after a reload** as "Interrupted by a reload. Re-add a file to resume". Cancel was the one terminal path that kept its breadcrumb (rewritten to `status: 'canceled'`), and `partitionUploadBreadcrumbs` never reads `status`. It now removes the crumb like every other terminal path — a net deletion.

**Plus four small ones:** `describeUploadError` delegates to `formatApiError`, so DRF's field-shaped 400s (locus > 72 chars, tags > 255 — neither input has a `maxLength`) name the field instead of `Request failed (400).`; `guessLocusFromFilename` gets a `(?<!\d)` anchor so `Add_ch_33792r` stops yielding `f.3792r`; the chunk-failure `console.error` is dev-gated like `lib/api-fetch`; and the staged Locus/Tags inputs get `htmlFor`/`id`.

## What the backend will and won't honour

Worth being precise, because it is what makes the cancel window a client-side problem. `abort_session` (api `pr/133`, `apps/uploads/services.py:392`) refuses **only** `PROCESSING`. `PENDING`, `UPLOADING`, `ASSEMBLED` and `COMPLETE` are all deleted on request — including the entire finalize duration, during which the server is streaming every chunk through sha256 into one assembled file. So a DELETE fired mid-finalize does not bounce harmlessly: it either loses the race (session already PROCESSING → 409, swallowed → "Canceled" for an image that publishes anyway) or wins it and `rmtree`s the chunk directory out from under the running assemble. The client has to not send it. That is what the `phase !== 'finalizing'` condition buys.

Still open on the backend and out of scope here: `finalize_session` dispatches `ingest_upload.delay(...)` while the row is still `ASSEMBLED`, so a DELETE in that sub-window can delete the session after the task is queued and orphan the assembled file. The tray no longer offers cancel there, but `dismissInterrupted` can still reach it for a crumb whose status lookup failed. A backend guard is the durable fix.

## For you to decide

- **`describeUploadError` now returns the house strings** — `Server error (500)` and `An unexpected error occurred` where it used to say `Request failed (500).` and `Upload failed.`. Two existing expectations moved with it. Unlocalized either way, but they are the strings the i18n sweep will have to key.
- **One new user-visible string**: the `Stop tracking <file>` aria-label. Three more change shape via `formatApiError`. `upload-tray.tsx` is already 100% hardcoded English, so this doesn't regress the bilingual rule — it adds a fourth string to the sweep.
- **The `(?<!\d)` anchor also blanks zero-padded 5-digit loci** — `Cotton_Nero_D_IV_f_00027r.tif` yielded `f.27r` before and yields `''` now. Trading a plausible-wrong guess for no guess is the right call (the field stays editable), but it is a real behaviour change, now pinned by a test and named in the docstring.
- **The search-engine task panel steps aside conditionally** — `right-[412px]` (380px panel + 16px gutter) is applied only while `items.length + interrupted.length > 0`, i.e. while the tray is actually rendered, so the normal state of that page is unchanged. `UploadManagerProvider` wraps the whole backoffice shell, so the page can just read the manager. Caveat: while both panels are up, the offset needs a >=792px viewport or the task panel clips off the left edge.

## Left alone on purpose

The i18n sweep (the French copy should be yours), transport tests for `putChunk`/`uploadImageFile`/`abortUploadSession`, the resume id re-key, and the orphaned-JP2 dead end (that one needs a backend sub-code on `destination_exists`). `.bundle-budget.json` is untouched — the review's advice stands: take main's file at merge time, then re-run `just bundle-budget-update` on the merged tree.

## Not verified

This branch has **not** been audited against the agreed plan or the over-engineering list: neither file is present on the machine this was prepared on (the scratchpad `plans/` directory does not exist). Treat "nothing was reintroduced from the over-engineering list" as unverified, not verified. The diff reads minimal on its own merits — no new abstraction layers, no config knobs, no single-use helpers beyond the four-line `abortSession` (two call sites) — but that is a judgement, not a check against the list.

**None of this changes the merge order.** `/api/v1/uploads/sessions/` still 404s until api #133 lands, and this branch adds a `DELETE` against the same surface. `UploadSessionViewSet.destroy` is confirmed present in api `pr/133` (`apps/uploads/views.py:68`, returns 204), so the endpoint is real once that merges — it is just not on api `main` today.

## Gates

`eslint`, `prettier --check`, `tsc --noEmit`, `vitest run` (99 files, 965 tests), `next build`, and `check-bundle-budget` (1.85 MiB / 2.04 MiB, 111 chunks) all green.

Each behavioural fix has a test observed failing against `b95d557` with the source changes reverted — **11 failures across the four touched suites**, restored and re-run green afterwards. Two of those eleven (`falls back to a status message when the body says nothing`, `handles chunk, upload-failed, generic and unknown errors`) fail at base only because the expected literals moved with the `formatApiError` delegation; they are expectation edits, not new behavioural coverage. The evidence for that delegation is `names the offending field on a DRF validation 400`.
---

Follows the review on #98. Branched off #98's head, so it can be merged straight into that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
