### PR TITLE
fix(carousel): safely render embedded HTML in carousel labels (#78)

### DIFF
--- a/components/backoffice/carousel/carousel-preview.test.tsx
+++ b/components/backoffice/carousel/carousel-preview.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { CarouselPreview } from './carousel-preview';
+import type { CarouselItem } from '@/types/backoffice';
+
+describe('CarouselPreview', () => {
+  it('renders embedded HTML in slide title safely without raw markup tags', () => {
+    const items: CarouselItem[] = [
+      {
+        id: 1,
+        title: 'Charter of <i>King Edgar</i> &amp; <b>St. Dunstan</b>',
+        url: '/manuscripts/1',
+        image: 'media/carousel/edgar.jpg',
+        weight: 1,
+      },
+    ];
+
+    const html = renderToStaticMarkup(<CarouselPreview items={items} />);
+
+    // Renders the HTML tags as elements
+    expect(html).toContain('<i>King Edgar</i>');
+    expect(html).toContain('<b>St. Dunstan</b>');
+    // img alt text should have tags stripped
+    expect(html).toContain('alt="Charter of King Edgar &amp;amp; St. Dunstan"');
+  });
+
+  it('renders empty preview placeholder when items list is empty', () => {
+    const html = renderToStaticMarkup(<CarouselPreview items={[]} />);
+    expect(html).toContain('border-dashed');
+  });
+});

--- a/components/backoffice/carousel/carousel-preview.tsx
+++ b/components/backoffice/carousel/carousel-preview.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ChevronRight, ImageIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getCarouselImageUrl } from '@/utils/api';
+import { sanitizeHtml, stripHtml } from '@/lib/sanitize-html';
 import type { CarouselItem } from '@/types/backoffice';
 
 interface CarouselPreviewProps {
@@ -58,7 +59,11 @@ export function CarouselPreview({ items }: CarouselPreviewProps) {
           {hasImage ? (
             <>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={imageUrl} alt={currentItem.title} className="h-full w-full object-cover" />
+              <img
+                src={imageUrl}
+                alt={stripHtml(currentItem.title)}
+                className="h-full w-full object-cover"
+              />
             </>
           ) : (
             <div className="flex h-full w-full items-center justify-center bg-muted">
@@ -111,7 +116,10 @@ export function CarouselPreview({ items }: CarouselPreviewProps) {
           {currentItem?.title && (
             <div className="absolute inset-x-0 bottom-0 px-4 pb-4">
               <div className="rounded-md border border-white/20 bg-black/55 px-3 py-2 backdrop-blur-sm">
-                <p className="text-sm font-medium text-white line-clamp-2">{currentItem.title}</p>
+                <p
+                  className="text-sm font-medium text-white line-clamp-2"
+                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(currentItem.title) }}
+                />
               </div>
               {currentItem.url && (
                 <p className="mt-1 text-xs text-white/75 truncate">{currentItem.url}</p>

--- a/components/backoffice/carousel/sortable-carousel-card.test.tsx
+++ b/components/backoffice/carousel/sortable-carousel-card.test.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { SortableCarouselCard } from './sortable-carousel-card';
+import type { CarouselItem } from '@/types/backoffice';
+
+// Mock dnd-kit hooks for static rendering
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+describe('SortableCarouselCard', () => {
+  it('renders embedded HTML in title safely and strips tags in alt', () => {
+    const item: CarouselItem = {
+      id: 42,
+      title: 'Manuscript with <i>Insular</i> script',
+      url: '/manuscripts/42',
+      image: 'media/carousel/ms42.jpg',
+      weight: 0,
+    };
+
+    const html = renderToStaticMarkup(
+      <SortableCarouselCard item={item} isSelected={false} onSelect={vi.fn()} onDelete={vi.fn()} />
+    );
+
+    expect(html).toContain('<i>Insular</i>');
+    expect(html).toContain('alt="Manuscript with Insular script"');
+  });
+});

--- a/components/backoffice/carousel/sortable-carousel-card.tsx
+++ b/components/backoffice/carousel/sortable-carousel-card.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { getCarouselImageUrl } from '@/utils/api';
+import { sanitizeHtml, stripHtml } from '@/lib/sanitize-html';
 import type { CarouselItem } from '@/types/backoffice';
 
 interface SortableCarouselCardProps {
@@ -68,14 +69,17 @@ export function SortableCarouselCard({
       <div className="h-12 w-20 shrink-0 rounded overflow-hidden bg-muted flex items-center justify-center">
         {hasImage ? (
           /* eslint-disable-next-line @next/next/no-img-element */
-          <img src={imageUrl} alt={item.title} className="h-full w-full object-cover" />
+          <img src={imageUrl} alt={stripHtml(item.title)} className="h-full w-full object-cover" />
         ) : (
           <ImageIcon className="h-5 w-5 text-muted-foreground/50" />
         )}
       </div>
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium truncate">{item.title}</p>
+        <p
+          className="text-sm font-medium truncate"
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(item.title) }}
+        />
         {item.url && <p className="text-xs text-muted-foreground truncate">{item.url}</p>}
       </div>
 

--- a/components/content/intro-section.tsx
+++ b/components/content/intro-section.tsx
@@ -8,6 +8,7 @@ import { ChevronRight, ChevronLeft, ChevronDown, Search, BookOpen } from 'lucide
 import { useTranslations } from 'next-intl';
 import type { CarouselItem } from '@/types/backoffice';
 import { fetchCarouselItems, getCarouselImageUrl } from '@/utils/api';
+import { sanitizeHtml, stripHtml } from '@/lib/sanitize-html';
 
 const ABOUT_MODELS_OF_AUTHORITY_PATH = '/about/about-models-of-authority';
 
@@ -165,7 +166,7 @@ export default function IntroSection() {
                   const slide = (
                     <Image
                       src={getCarouselImageUrl(item.image)}
-                      alt={item.title}
+                      alt={stripHtml(item.title)}
                       fill
                       // Only animate the visible slide — running the ken-burns
                       // transform on hidden (opacity-0) slides is wasted
@@ -242,16 +243,14 @@ export default function IntroSection() {
                       href={currentItemUrl}
                       className="text-white text-lg font-semibold hover:text-accent transition-colors truncate block"
                       style={{ fontFamily: 'var(--font-display)' }}
-                    >
-                      {currentItem?.title}
-                    </Link>
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(currentItem.title) }}
+                    />
                   ) : (
                     <p
                       className="text-white text-lg font-semibold truncate"
                       style={{ fontFamily: 'var(--font-display)' }}
-                    >
-                      {currentItem?.title}
-                    </p>
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(currentItem.title) }}
+                    />
                   )}
                 </div>
 

--- a/lib/sanitize-html.test.ts
+++ b/lib/sanitize-html.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeHtml } from './sanitize-html';
+import { sanitizeHtml, stripHtml } from './sanitize-html';
 
 describe('sanitizeHtml', () => {
   it('allows safe HTML tags', () => {
@@ -96,5 +96,28 @@ describe('sanitizeHtml', () => {
 
   it('returns empty string for empty input', () => {
     expect(sanitizeHtml('')).toBe('');
+  });
+});
+
+describe('stripHtml', () => {
+  it('strips HTML formatting tags and returns plain text', () => {
+    expect(stripHtml('<i>St. Dunstan</i> &amp; <b>King Edgar</b>')).toBe(
+      'St. Dunstan &amp; King Edgar'
+    );
+  });
+
+  it('strips complex nested markup', () => {
+    expect(
+      stripHtml('<p>Charter from <a href="/manuscripts/1"><span>Glastonbury</span></a></p>')
+    ).toBe('Charter from Glastonbury');
+  });
+
+  it('returns plain text unchanged (trimmed)', () => {
+    expect(stripHtml('  Plain charter label  ')).toBe('Plain charter label');
+  });
+
+  it('returns empty string for empty or whitespace-only input', () => {
+    expect(stripHtml('')).toBe('');
+    expect(stripHtml('   ')).toBe('');
   });
 });

--- a/lib/sanitize-html.ts
+++ b/lib/sanitize-html.ts
@@ -241,3 +241,12 @@ export function sanitizeHtml(dirty: string, options: SanitizeOptions = {}): stri
     DOMPurify.removeHook('afterSanitizeAttributes', iframeHook);
   }
 }
+
+/**
+ * Strip all HTML tags, returning plain text.
+ * Useful for alt attributes, tooltips, or plain text contexts.
+ */
+export function stripHtml(dirty: string): string {
+  if (!dirty) return '';
+  return DOMPurify.sanitize(dirty, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim();
+}


### PR DESCRIPTION
## Summary
Fixes #78
Related to archetype-pal/project-discussions#8

### Context & Changes
Carousel slide captions and labels may contain embedded HTML formatting tags (such as `<i>...</i>`, `<em>...</em>`, `<b>...</b>`, or `&amp;`) from legacy imported data. Previously, these were either rendered as raw string tags or unmanaged.

- **`lib/sanitize-html.ts`**: Added and exported `stripHtml(dirty)` helper to strip HTML tags for plain text contexts (such as image `alt` attributes).
- **`components/content/intro-section.tsx`**: Updated slide captions on the homepage hero carousel to safely render formatted HTML via `sanitizeHtml` and use `stripHtml` for image `alt` attributes.
- **`components/backoffice/carousel/carousel-preview.tsx`**: Updated the live preview title overlay to safely render formatted HTML and use `stripHtml` for image `alt`.
- **`components/backoffice/carousel/sortable-carousel-card.tsx`**: Updated card title in the backoffice reorder list to safely render formatted HTML.
- **Tests**: Added comprehensive unit tests in `lib/sanitize-html.test.ts`, `components/backoffice/carousel/carousel-preview.test.tsx`, and `components/backoffice/carousel/sortable-carousel-card.test.tsx`.

### Verification
- `pnpm lint` passed with 0 errors.
- `pnpm format` passed.
- `pnpm vitest run` passed (all 122 test files / 1,218 tests passing).
- `pnpm build` passed successfully.