### PR TITLE
feat(publications): display keywords and themes on publication cards and detail pages

### DIFF
--- a/components/content/blog-post-preview.test.tsx
+++ b/components/content/blog-post-preview.test.tsx
@@ -23,4 +23,76 @@ describe('BlogPostPreview', () => {
     expect(html).toContain('href="#refnote1"');
     expect(html).toContain('href="/manuscripts/259"');
   });
+
+  it('renders keywords as badges when keywords string is provided', () => {
+    const html = renderToStaticMarkup(
+      <BlogPostPreview
+        title="Medieval Manuscripts"
+        author="Alice Smith"
+        date="2020-01-01T00:00:00Z"
+        excerpt="<p>An overview.</p>"
+        slug="/publications/blogs/medieval-manuscripts"
+        keywords="palaeography, charters, medieval history"
+        showShareBtns={false}
+        showReadMoreBtn={false}
+      />
+    );
+
+    expect(html).toContain('data-testid="publication-keywords"');
+    expect(html).toContain('palaeography');
+    expect(html).toContain('charters');
+    expect(html).toContain('medieval history');
+  });
+
+  it('handles quotes and whitespace in keywords gracefully', () => {
+    const html = renderToStaticMarkup(
+      <BlogPostPreview
+        title="Medieval Manuscripts"
+        author="Alice Smith"
+        date="2020-01-01T00:00:00Z"
+        excerpt="<p>An overview.</p>"
+        slug="/publications/blogs/medieval-manuscripts"
+        keywords='"insular script", "anglo-saxon", latin'
+        showShareBtns={false}
+        showReadMoreBtn={false}
+      />
+    );
+
+    expect(html).toContain('insular script');
+    expect(html).toContain('anglo-saxon');
+    expect(html).toContain('latin');
+    expect(html).not.toContain('&quot;insular script&quot;');
+  });
+
+  it('does not render keywords container when keywords is undefined or empty', () => {
+    const htmlEmpty = renderToStaticMarkup(
+      <BlogPostPreview
+        title="No Keywords"
+        author="Bob"
+        date="2020-01-01T00:00:00Z"
+        excerpt="<p>None.</p>"
+        slug="/publications/blogs/no-keywords"
+        keywords=""
+        showShareBtns={false}
+        showReadMoreBtn={false}
+      />
+    );
+
+    expect(htmlEmpty).not.toContain('data-testid="publication-keywords"');
+
+    const htmlNull = renderToStaticMarkup(
+      <BlogPostPreview
+        title="No Keywords"
+        author="Bob"
+        date="2020-01-01T00:00:00Z"
+        excerpt="<p>None.</p>"
+        slug="/publications/blogs/no-keywords"
+        keywords={null}
+        showShareBtns={false}
+        showReadMoreBtn={false}
+      />
+    );
+
+    expect(htmlNull).not.toContain('data-testid="publication-keywords"');
+  });
 });

--- a/components/content/blog-post-preview.test.tsx
+++ b/components/content/blog-post-preview.test.tsx
@@ -1,8 +1,34 @@
 import * as React from 'react';
+import { render } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import BlogPostPreview from './blog-post-preview';
+
+const renderPreview = (keywords?: string | null) =>
+  render(
+    <BlogPostPreview
+      title="Medieval Manuscripts"
+      author="Alice Smith"
+      date="2020-01-01T00:00:00Z"
+      excerpt="<p>An overview.</p>"
+      slug="/publications/blogs/medieval-manuscripts"
+      keywords={keywords}
+      showShareBtns={false}
+      showReadMoreBtn={false}
+    />
+  );
+
+/** The badge labels, in order, or null when the group is not rendered at all. */
+const badges = (keywords?: string | null): string[] | null => {
+  const { container, unmount } = renderPreview(keywords);
+  const group = container.querySelector('[data-testid="publication-keywords"]');
+  const labels = group
+    ? Array.from(group.children).map((badge) => badge.textContent?.trim() ?? '')
+    : null;
+  unmount();
+  return labels;
+};
 
 describe('BlogPostPreview', () => {
   it('renders publication HTML through the scoped legacy renderer', () => {
@@ -24,75 +50,41 @@ describe('BlogPostPreview', () => {
     expect(html).toContain('href="/manuscripts/259"');
   });
 
-  it('renders keywords as badges when keywords string is provided', () => {
-    const html = renderToStaticMarkup(
-      <BlogPostPreview
-        title="Medieval Manuscripts"
-        author="Alice Smith"
-        date="2020-01-01T00:00:00Z"
-        excerpt="<p>An overview.</p>"
-        slug="/publications/blogs/medieval-manuscripts"
-        keywords="palaeography, charters, medieval history"
-        showShareBtns={false}
-        showReadMoreBtn={false}
-      />
-    );
-
-    expect(html).toContain('data-testid="publication-keywords"');
-    expect(html).toContain('palaeography');
-    expect(html).toContain('charters');
-    expect(html).toContain('medieval history');
+  it('renders one badge per keyword', () => {
+    expect(badges('palaeography, charters, medieval history')).toEqual([
+      'palaeography',
+      'charters',
+      'medieval history',
+    ]);
   });
 
-  it('handles quotes and whitespace in keywords gracefully', () => {
-    const html = renderToStaticMarkup(
-      <BlogPostPreview
-        title="Medieval Manuscripts"
-        author="Alice Smith"
-        date="2020-01-01T00:00:00Z"
-        excerpt="<p>An overview.</p>"
-        slug="/publications/blogs/medieval-manuscripts"
-        keywords='"insular script", "anglo-saxon", latin'
-        showShareBtns={false}
-        showReadMoreBtn={false}
-      />
-    );
-
-    expect(html).toContain('insular script');
-    expect(html).toContain('anglo-saxon');
-    expect(html).toContain('latin');
-    expect(html).not.toContain('&quot;insular script&quot;');
+  it('reads the quoted form the API actually sends', () => {
+    // Tagulous' render_tags quotes any tag holding a comma or a space and doubles
+    // inner quotes, so a plain comma split would cut the first one into three.
+    expect(badges('"edinburgh, scotland", latin')).toEqual(['edinburgh, scotland', 'latin']);
+    expect(badges('"insular script", "anglo-saxon", latin')).toEqual([
+      'insular script',
+      'anglo-saxon',
+      'latin',
+    ]);
+    expect(badges('"great ""seal"""')).toEqual(['great "seal"']);
   });
 
-  it('does not render keywords container when keywords is undefined or empty', () => {
-    const htmlEmpty = renderToStaticMarkup(
-      <BlogPostPreview
-        title="No Keywords"
-        author="Bob"
-        date="2020-01-01T00:00:00Z"
-        excerpt="<p>None.</p>"
-        slug="/publications/blogs/no-keywords"
-        keywords=""
-        showShareBtns={false}
-        showReadMoreBtn={false}
-      />
-    );
+  it('drops the category keyword already shown as the publication type', () => {
+    expect(badges('Blog, palaeography')).toEqual(['palaeography']);
+    expect(badges('News')).toBeNull();
+  });
 
-    expect(htmlEmpty).not.toContain('data-testid="publication-keywords"');
+  it('renders no keyword group when there is nothing to show', () => {
+    expect(badges('')).toBeNull();
+    expect(badges(null)).toBeNull();
+    expect(badges(undefined)).toBeNull();
+  });
 
-    const htmlNull = renderToStaticMarkup(
-      <BlogPostPreview
-        title="No Keywords"
-        author="Bob"
-        date="2020-01-01T00:00:00Z"
-        excerpt="<p>None.</p>"
-        slug="/publications/blogs/no-keywords"
-        keywords={null}
-        showShareBtns={false}
-        showReadMoreBtn={false}
-      />
-    );
-
-    expect(htmlNull).not.toContain('data-testid="publication-keywords"');
+  it('names the keyword group for assistive tech', () => {
+    const { container, unmount } = renderPreview('palaeography');
+    const group = container.querySelector('[data-testid="publication-keywords"]');
+    expect(group?.getAttribute('aria-label')).toBe('Keywords');
+    unmount();
   });
 });

--- a/components/content/blog-post-preview.tsx
+++ b/components/content/blog-post-preview.tsx
@@ -20,13 +20,38 @@ const formatDate = (value: string) => {
   });
 };
 
+// The API sends Tagulous' render_tags output: tags joined with ", ", any tag
+// containing a comma or a space wrapped in quotes, inner quotes doubled ("").
+// Splitting on commas first would cut a quoted tag in half.
 const parseKeywords = (value?: string | null): string[] => {
   if (!value) return [];
-  return value
-    .split(',')
-    .map((k) => k.trim().replace(/^["']|["']$/g, ''))
-    .filter(Boolean);
+  const tags: string[] = [];
+  let tag = '';
+  let inQuote = false;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === '"') {
+      if (value[i + 1] === '"') {
+        tag += '"';
+        i++;
+      } else {
+        inQuote = !inQuote;
+      }
+    } else if (char === ',' && !inQuote) {
+      tags.push(tag);
+      tag = '';
+    } else {
+      tag += char;
+    }
+  }
+  tags.push(tag);
+  return tags.map((t) => t.trim()).filter(Boolean);
 };
+
+// The migrated corpus stores the publication's own category as a keyword on most
+// publications. It is already shown as the type label in the meta row, so drop it
+// rather than badge the same word twice.
+const CATEGORY_KEYWORDS = new Set(['news', 'blog', 'feature article']);
 
 interface BlogPostPreviewProps {
   title: string;
@@ -52,7 +77,7 @@ export default function BlogPostPreview({
   showReadMoreBtn = true,
 }: BlogPostPreviewProps) {
   const t = useTranslations('content');
-  const tags = parseKeywords(keywords);
+  const tags = parseKeywords(keywords).filter((tag) => !CATEGORY_KEYWORDS.has(tag.toLowerCase()));
   const publicationLabel = slug.includes('/publications/feature')
     ? t('blog.typeFeature')
     : slug.includes('/publications/blogs')
@@ -92,6 +117,7 @@ export default function BlogPostPreview({
       {tags.length > 0 && (
         <div
           className="flex flex-wrap items-center gap-1.5 mb-4"
+          aria-label={t('blog.keywordsLabel')}
           data-testid="publication-keywords"
         >
           {tags.map((tag) => (

--- a/components/content/blog-post-preview.tsx
+++ b/components/content/blog-post-preview.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { User, Calendar, Newspaper, MessageSquare, ArrowRight } from 'lucide-react';
+import { User, Calendar, Newspaper, MessageSquare, ArrowRight, Tag } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
 import ShareButtons from './share-buttons';
 import { renderPublicationHtml } from '@/lib/publication-html';
 
@@ -19,12 +20,21 @@ const formatDate = (value: string) => {
   });
 };
 
+const parseKeywords = (value?: string | null): string[] => {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((k) => k.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
+};
+
 interface BlogPostPreviewProps {
   title: string;
   author: string;
   date: string;
   excerpt: string;
   slug: string;
+  keywords?: string | null;
   commentsCount?: number;
   showShareBtns: boolean;
   showReadMoreBtn: boolean;
@@ -36,11 +46,13 @@ export default function BlogPostPreview({
   date,
   excerpt,
   slug,
+  keywords,
   commentsCount = 0,
   showShareBtns = true,
   showReadMoreBtn = true,
 }: BlogPostPreviewProps) {
   const t = useTranslations('content');
+  const tags = parseKeywords(keywords);
   const publicationLabel = slug.includes('/publications/feature')
     ? t('blog.typeFeature')
     : slug.includes('/publications/blogs')
@@ -76,6 +88,21 @@ export default function BlogPostPreview({
           {t('blog.comments', { count: commentsCount })}
         </Link>
       </div>
+
+      {tags.length > 0 && (
+        <div
+          className="flex flex-wrap items-center gap-1.5 mb-4"
+          data-testid="publication-keywords"
+        >
+          {tags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs font-normal gap-1">
+              <Tag className="h-3 w-3 text-muted-foreground" />
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      )}
+
       {/* <div>, not <p>: excerpts are authored HTML and may contain block
           elements (e.g. <p>), which a <p> can't legally nest — the browser would
           reparent them and desync from the server HTML → hydration mismatch. */}

--- a/components/content/paginated-publications.tsx
+++ b/components/content/paginated-publications.tsx
@@ -127,6 +127,7 @@ export default function PaginatedPublications({
                       date={article.published_at ?? ''}
                       excerpt={article.preview}
                       slug={`${basePath}/${article.slug}`}
+                      keywords={article.keywords}
                       commentsCount={article.number_of_comments}
                       showShareBtns={false}
                       showReadMoreBtn={true}

--- a/components/content/publication-pages.tsx
+++ b/components/content/publication-pages.tsx
@@ -105,6 +105,7 @@ export async function PublicationDetailPage({
             date={item.published_at ?? ''}
             excerpt={item.content}
             slug={`${config.routeBase}/${item.slug}`}
+            keywords={item.keywords}
             commentsCount={item.number_of_comments}
             showShareBtns
             showReadMoreBtn={false}

--- a/messages/en.json
+++ b/messages/en.json
@@ -434,7 +434,8 @@
       "recentSection": "Recent {title}",
       "backToList": "Back to list",
       "viewAll": "View all {title}",
-      "publicationFallbackTitle": "Publication"
+      "publicationFallbackTitle": "Publication",
+      "keywordsLabel": "Keywords"
     },
     "publicationKinds": {
       "news": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -434,7 +434,8 @@
       "recentSection": "{title} récent(e)s",
       "backToList": "Retour à la liste",
       "viewAll": "Voir tous les {title}",
-      "publicationFallbackTitle": "Publication"
+      "publicationFallbackTitle": "Publication",
+      "keywordsLabel": "Mots-clés"
     },
     "publicationKinds": {
       "news": {


### PR DESCRIPTION
Closes #80

### Description
Surfaces publication keywords/themes as subtle tag badges with a tag icon on publication previews (Blog, News, Feature Articles) and detail pages.

### Changes
- `BlogPostPreview`: Added `keywords?: string | null` prop and tag rendering with `Badge` component and lucide `Tag` icon.
- `BlogPostPreview`: Added keyword string parser supporting comma separation and quotes.
- `PublicationDetailPage`: Passed `keywords={item.keywords}` to `BlogPostPreview`.
- `PaginatedPublications`: Passed `keywords={article.keywords}` to publication card `BlogPostPreview`.
- Added translations `content.blog.keywordsLabel` for English (`Keywords`) and French (`Mots-clés`).
- Unit tests added in `components/content/blog-post-preview.test.tsx`.