### PR TITLE
fix(filters): show full facet label on hover when truncated

### DIFF
--- a/components/filters/active-facet-tags.tsx
+++ b/components/filters/active-facet-tags.tsx
@@ -56,7 +56,9 @@ export function ActiveFacetTags({
                 : 'bg-muted'
             )}
           >
-            <span className="max-w-[180px] truncate">{item.label}</span>
+            <span title={item.label} className="max-w-[180px] truncate">
+              {item.label}
+            </span>
             <button
               type="button"
               onClick={() => onRemove(item)}

--- a/components/filters/facet-panel.tsx
+++ b/components/filters/facet-panel.tsx
@@ -170,7 +170,10 @@ export function FacetPanel({
                   className="group flex w-full items-center gap-1.5 rounded-md border border-destructive/40 bg-background/40 px-2 py-1 text-left text-[13px] transition-colors hover:bg-destructive/10"
                 >
                   <Ban className="h-3 w-3 shrink-0 text-destructive/70" />
-                  <span className="min-w-0 flex-1 truncate text-muted-foreground line-through decoration-destructive/50">
+                  <span
+                    title={value}
+                    className="min-w-0 flex-1 truncate text-muted-foreground line-through decoration-destructive/50"
+                  >
                     {value}
                   </span>
                   <X className="h-3.5 w-3.5 shrink-0 text-destructive/70 transition-colors group-hover:text-destructive" />
@@ -208,7 +211,9 @@ export function FacetPanel({
                         : 'hover:bg-muted/60'
                     )}
                   >
-                    <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                    <span title={item.label} className="min-w-0 flex-1 truncate">
+                      {item.label}
+                    </span>
                     <span className="inline-flex shrink-0 items-center gap-2">
                       <span className="tabular-nums text-muted-foreground">{item.count}</span>
                       {showSparklines && (

--- a/components/filters/facet-tree-panel.tsx
+++ b/components/filters/facet-tree-panel.tsx
@@ -153,7 +153,9 @@ export function FacetTreePanel({
                         nodeExpanded ? 'rotate-0' : '-rotate-90'
                       )}
                     />
-                    <span className="truncate">{node.component}</span>
+                    <span title={node.component} className="truncate">
+                      {node.component}
+                    </span>
                   </span>
                   <span className="tabular-nums text-muted-foreground">{node.total}</span>
                 </button>
@@ -174,7 +176,9 @@ export function FacetTreePanel({
                             )}
                             onClick={() => onSelect(child.value, isSelected)}
                           >
-                            <span className="truncate">{child.label}</span>
+                            <span title={child.label} className="truncate">
+                              {child.label}
+                            </span>
                             <span className="inline-flex shrink-0 items-center gap-2">
                               <span className="tabular-nums text-muted-foreground">
                                 {child.count}


### PR DESCRIPTION
## Summary
- Adds a `title` attribute to every truncated facet-value label so the full text shows on hover.
- Covers all filters (repository, repository city, place, allograph, character, component features, etc.) since they share `FacetPanel` / `FacetTreePanel`, plus excluded values and active filter tags via `ActiveFacetTags`.

BEFORE

<img width="338" height="364" alt="Image" src="https://github.com/user-attachments/assets/119008dd-6e8f-4807-80ed-5a4f7f5e28bd" />

NOW 

<img width="338" height="364" alt="Image" src="https://github.com/user-attachments/assets/a6b0746f-dca7-4f14-8daf-cd30a47f0f87" />